### PR TITLE
Add read transaction support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [UNRELEASED] - YYYY-MM-DD
 
 ### Added
+- Reads all partitions within the same transaction. This guarantees a consistent snapshot of the graph ([issue #6](https://github.com/G-Research/spark-dgraph-connector/issues/6)).
+  However, concurrent mutations can reduce the lifetime of a transaction.
 - Add example how to load Dgraph data in PySpark. Fixed dependency conflicts between connector dependencies and Spark.
+
+### Changed
+- Moved Dgraph client to 20.03.1 and Dgraph test cluster to 20.07.0.
 
 ## [0.4.0] - 2020-07-24
 
@@ -31,7 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Load data from Dgraph cluster as [GraphFrames](https://graphframes.github.io/graphframes/docs/_site/index.html) `GraphFrame`.
 - Use exact uid cardinality for uid range partitioning. Combined with predicate partitioning, large
-  predicates get split into more partitions than small predicates.
+  predicates get split into more partitions than small predicates ([issue #2](https://github.com/G-Research/spark-dgraph-connector/issues/2)).
 - Improve performance of `PredicatePartitioner` for a single predicate per partition (`dgraph.partitioner.predicate.predicatesPerPartition=1`).
   This becomes the new default for this partitioner.
 - Move to Spark 3.0.0 release (was 3.0.0-preview2).

--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ With PySpark (pyspark 2.4.2 and ≥3.0) you can use the `spark.read.format(…).
 The connector is under continuous development. It has the following known limitations:
 
 - **Read-only**: The connector does not support mutating the graph ([issue #8](https://github.com/G-Research/spark-dgraph-connector/issues/8)).
-- **Not transaction-aware**: Individual partitions do not read the same transaction. The graph should not be
-  modified while reading it into Spark ([issue #6](https://github.com/G-Research/spark-dgraph-connector/issues/6)).
+- **Limited Lifetime of Transactions**: The connector reads all partitions within the same transaction, but concurrent mutations can reduce the lifetime of that transaction.
 - **Language tags & facets**: The connector cannot read any string values with language tags or facets.
 
 Beside the **language tags & facets**, which is a limitation of Dgraph, all the other issues mentioned
@@ -78,7 +77,7 @@ Launch the Python Spark REPL (pyspark 2.4.2 and ≥3.0) with the Spark Dgraph Co
 
     pyspark --packages uk.co.gresearch.spark:spark-dgraph-connector_2.12:0.4.2-3.0 --conf spark.driver.userClassPathFirst=true
 
-Run your Python script that uses PySpark (pyspark 2.4.2 and ≥3.0) and the Spark Dgraph Connector (version ≥0.4.2) via `spark-submit`:
+Run your Python scripts that use PySpark (pyspark 2.4.2 and ≥3.0) and the Spark Dgraph Connector (version ≥0.4.2) via `spark-submit`:
 
     spark-submit --packages uk.co.gresearch.spark:spark-dgraph-connector_2.12:0.4.2-3.0 --conf spark.driver.userClassPathFirst=true [script.py]
 
@@ -555,7 +554,7 @@ However, this would be would slow, but it proves the connector can handle any si
 
 ## Dependencies
 
-The GRPC library used by the dgraph client requires `guava ≥ 20.0`, where `≥ 24.1.1-jre` is recommended, hence the:
+The GRPC library used by the dgraph client requires Guava ≥20.0, where ≥24.1.1-jre is recommended, hence the:
 
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -577,7 +576,7 @@ The GRPC library used by the dgraph client requires `guava ≥ 20.0`, where `≥
       at io.grpc.internal.AbstractManagedChannelImplBuilder.<clinit>(AbstractManagedChannelImplBuilder.java:84)
       at uk.co.gresearch.spark.dgraph.connector.package$.toChannel(package.scala:113)
 
-Furthermore, we need to set `protobuf-java ≥ 3.4.0` in the `pom.xml` file:
+Furthermore, we need to set `protobuf-java` ≥3.4.0 in the `pom.xml` file:
 
     <dependency>
       <groupId>com.google.protobuf</groupId>

--- a/dgraph-instance.start.sh
+++ b/dgraph-instance.start.sh
@@ -1,4 +1,4 @@
 # keep env var name in-sync with uk.co.gresearch.spark.dgraph.DgraphTestCluster.DgraphVersionEnvVar
 # keep default value in-sync with uk.co.gresearch.spark.dgraph.DgraphTestCluster.DgraphDefaltVersion
-version=${DGRAPH_TEST_CLUSTER_VERSION:-20.03.4}
+version=${DGRAPH_TEST_CLUSTER_VERSION:-20.07.0}
 docker run --rm -it -p 8080:8080 -p 9080:9080 -p 8000:8000 -p 6080:6080 -v "$(cd "$(dirname "$0")"; pwd)/dgraph-instance:/dgraph" dgraph/dgraph:v${version} /bin/bash -c "dgraph-ratel & dgraph zero & dgraph alpha --lru_mb 1024 --whitelist 0.0.0.0/0"

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>io.dgraph</groupId>
       <artifactId>dgraph4j</artifactId>
-      <version>20.03.0</version>
+      <version>20.03.1</version>
       <exclusions>
         <!-- Spark comes with a specific netty version, we want to compile against that version -->
         <!-- This fixes: java.lang.ClassCastException: class io.netty.channel.epoll.EpollSocketChannel -->

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/executor/TransactionProvider.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/executor/TransactionProvider.scala
@@ -15,17 +15,20 @@
  */
 
 package uk.co.gresearch.spark.dgraph.connector.executor
-import uk.co.gresearch.spark.dgraph.connector.{Partition, Transaction}
 
-case class DgraphExecutorProvider(transaction: Transaction) extends ExecutorProvider {
+import io.grpc.ManagedChannel
+import uk.co.gresearch.spark.dgraph.connector.{Target, Transaction, getClientFromChannel, toChannel}
 
-  /**
-   * Provide an executor for the given partition.
-   *
-   * @param partition a partitioon
-   * @return an executor
-   */
-  override def getExecutor(partition: Partition): JsonGraphQlExecutor =
-    DgraphExecutor(transaction, partition.targets)
-
+trait TransactionProvider {
+  def getTransaction(targets: Seq[Target]): Transaction = {
+    val channels: Seq[ManagedChannel] = targets.map(toChannel)
+    try {
+      val client = getClientFromChannel(channels)
+      val transaction = client.newReadOnlyTransaction()
+      val response = transaction.query("{ result (func: uid(0x0)) { } }")
+      Transaction(response.getTxn)
+    } finally {
+      channels.foreach(_.shutdown())
+    }
+  }
 }

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/package.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/package.scala
@@ -21,6 +21,7 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
 import io.dgraph.DgraphGrpc.DgraphStub
+import io.dgraph.DgraphProto.TxnContext
 import io.dgraph.{DgraphClient, DgraphGrpc}
 import io.grpc.ManagedChannel
 import io.grpc.netty.NettyChannelBuilder
@@ -199,6 +200,8 @@ package object connector {
   def getClientFromTargets(targets: Seq[Target]): DgraphClient = getClientFromStubs(targets.map(toStub))
 
   def getClient(targets: Seq[Target]): DgraphClient = getClientFromTargets(targets)
+
+  case class Transaction(context: TxnContext)
 
   implicit class DgraphDataFrameReader(reader: DataFrameReader) {
 

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/ConfigPartitionerOption.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/ConfigPartitionerOption.scala
@@ -26,13 +26,15 @@ class ConfigPartitionerOption extends PartitionerProviderOption
 
   override def getPartitioner(schema: Schema,
                               clusterState: ClusterState,
+                              transaction: Transaction,
                               options: CaseInsensitiveStringMap): Option[Partitioner] =
     getStringOption(PartitionerOption, options)
-      .map(getPartitioner(_, schema, clusterState, options))
+      .map(getPartitioner(_, schema, clusterState, transaction, options))
 
   def getPartitioner(partitionerName: String,
                      schema: Schema,
                      clusterState: ClusterState,
+                     transaction: Transaction,
                      options: CaseInsensitiveStringMap): Partitioner =
     partitionerName match {
       case SingletonPartitionerOption => SingletonPartitioner(getAllClusterTargets(clusterState), schema)
@@ -51,8 +53,8 @@ class ConfigPartitionerOption extends PartitionerProviderOption
         UidRangePartitioner(singleton, uidsPerPartition, estimator)
       case option if option.endsWith(s"+${UidRangePartitionerOption}") =>
         val name = option.substring(0, option.indexOf('+'))
-        val partitioner = getPartitioner(name, schema, clusterState, options)
-        getPartitioner(UidRangePartitionerOption, schema, clusterState, options)
+        val partitioner = getPartitioner(name, schema, clusterState, transaction, options)
+        getPartitioner(UidRangePartitionerOption, schema, clusterState, transaction, options)
           .asInstanceOf[UidRangePartitioner].copy(partitioner = partitioner)
       case unknown => throw new IllegalArgumentException(s"Unknown partitioner: $unknown")
     }

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/DefaultPartitionerOption.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/DefaultPartitionerOption.scala
@@ -23,7 +23,8 @@ class DefaultPartitionerOption extends ConfigPartitionerOption {
 
   override def getPartitioner(schema: Schema,
                               clusterState: ClusterState,
+                              transaction: Transaction,
                               options: CaseInsensitiveStringMap): Option[Partitioner] =
-    Some(getPartitioner(PartitionerDefault, schema, clusterState, options))
+    Some(getPartitioner(PartitionerDefault, schema, clusterState, transaction, options))
 
 }

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/PartitionerProvider.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/PartitionerProvider.scala
@@ -17,7 +17,7 @@
 package uk.co.gresearch.spark.dgraph.connector.partitioner
 
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
-import uk.co.gresearch.spark.dgraph.connector.{ClusterState, Schema}
+import uk.co.gresearch.spark.dgraph.connector.{ClusterState, Schema, Transaction}
 
 trait PartitionerProvider {
 
@@ -28,9 +28,10 @@ trait PartitionerProvider {
 
   def getPartitioner(schema: Schema,
                      clusterState: ClusterState,
+                     transaction: Transaction,
                      options: CaseInsensitiveStringMap): Partitioner =
     partitionerOptions
-      .flatMap(_.getPartitioner(schema, clusterState, options))
+      .flatMap(_.getPartitioner(schema, clusterState, transaction, options))
       .headOption
       .getOrElse(throw new RuntimeException("Could not find any suitable partitioner"))
 

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/PartitionerProviderOption.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/PartitionerProviderOption.scala
@@ -17,12 +17,13 @@
 package uk.co.gresearch.spark.dgraph.connector.partitioner
 
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
-import uk.co.gresearch.spark.dgraph.connector.{ClusterState, Schema, Target}
+import uk.co.gresearch.spark.dgraph.connector.{ClusterState, Schema, Transaction}
 
 trait PartitionerProviderOption {
 
   def getPartitioner(schema: Schema,
                      clusterState: ClusterState,
+                     transaction: Transaction,
                      options: CaseInsensitiveStringMap): Option[Partitioner]
 
 }

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/sources/EdgeSource.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/sources/EdgeSource.scala
@@ -22,15 +22,16 @@ import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import uk.co.gresearch.spark.dgraph.connector._
 import uk.co.gresearch.spark.dgraph.connector.encoder.EdgeEncoder
-import uk.co.gresearch.spark.dgraph.connector.executor.DgraphExecutorProvider
+import uk.co.gresearch.spark.dgraph.connector.executor.{DgraphExecutorProvider, TransactionProvider}
 import uk.co.gresearch.spark.dgraph.connector.model.EdgeTableModel
 import uk.co.gresearch.spark.dgraph.connector.partitioner.PartitionerProvider
-import uk.co.gresearch.spark.dgraph.connector._
 
 class EdgeSource() extends TableProviderBase
   with TargetsConfigParser with SchemaProvider
-  with ClusterStateProvider with PartitionerProvider {
+  with ClusterStateProvider with PartitionerProvider
+  with TransactionProvider {
 
   override def shortName(): String = "dgraph-edges"
 
@@ -42,11 +43,12 @@ class EdgeSource() extends TableProviderBase
                         properties: util.Map[String, String]): Table = {
     val options = new CaseInsensitiveStringMap(properties)
     val targets = getTargets(options)
+    val transaction = getTransaction(targets)
+    val execution = DgraphExecutorProvider(transaction)
     val schema = getSchema(targets).filter(_.isEdge)
     val clusterState = getClusterState(targets)
-    val partitioner = getPartitioner(schema, clusterState, options)
+    val partitioner = getPartitioner(schema, clusterState, transaction, options)
     val encoder = EdgeEncoder(schema.predicateMap)
-    val execution = DgraphExecutorProvider()
     val chunkSize = getIntOption(ChunkSizeOption, options, ChunkSizeDefault)
     val model = EdgeTableModel(execution, encoder, chunkSize)
     TripleTable(partitioner, model, clusterState.cid)

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/DgraphTestCluster.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/DgraphTestCluster.scala
@@ -19,6 +19,7 @@ package uk.co.gresearch.spark.dgraph
 import java.util.UUID
 
 import com.google.gson.{Gson, JsonArray, JsonObject}
+import io.dgraph.DgraphProto.TxnContext
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.types.StructType
 import org.scalatest.{Assertions, BeforeAndAfterAll, Suite}
@@ -26,7 +27,7 @@ import requests.{RequestBlob, Response}
 import uk.co.gresearch.spark.dgraph.DgraphTestCluster.isDgraphClusterRunning
 import uk.co.gresearch.spark.dgraph.connector.encoder.{JsonNodeInternalRowEncoder, NoColumnInfo}
 import uk.co.gresearch.spark.dgraph.connector.executor.DgraphExecutor
-import uk.co.gresearch.spark.dgraph.connector.{ClusterStateProvider, GraphQl, Logging, Target, Uid}
+import uk.co.gresearch.spark.dgraph.connector.{ClusterStateProvider, GraphQl, Logging, Target, Transaction, Uid}
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
@@ -103,7 +104,8 @@ trait DgraphTestCluster extends BeforeAndAfterAll with Logging { this: Suite =>
 
     @tailrec
     def attempt(no: Int, limit: Int): Uid = {
-      val json = DgraphExecutor(Seq(Target(cluster.grpc))).query(query)
+      val transaction = Transaction(TxnContext.newBuilder().build())
+      val json = DgraphExecutor(transaction, Seq(Target(cluster.grpc))).query(query)
       log.debug(s"retrieved dgraph.graphql.schema node: ${json.string}")
 
       val encoder = TestEncoder()

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestPartition.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestPartition.scala
@@ -16,6 +16,7 @@
 
 package uk.co.gresearch.spark.dgraph.connector
 
+import io.dgraph.DgraphProto.TxnContext
 import org.scalatest.FunSpec
 import uk.co.gresearch.spark.dgraph.DgraphTestCluster
 import uk.co.gresearch.spark.dgraph.connector.encoder.TypedTripleEncoder
@@ -40,7 +41,8 @@ class TestPartition extends FunSpec with SchemaProvider with DgraphTestCluster {
         val schema = Schema(syntheticPredicates ++ existingPredicates)
         val partition = Partition(targets).has(schema.predicates)
         val encoder = TypedTripleEncoder(schema.predicateMap)
-        val execution = DgraphExecutorProvider()
+        val transaction = Transaction(TxnContext.newBuilder().build())
+        val execution = DgraphExecutorProvider(transaction)
         val model = TripleTableModel(execution, encoder, ChunkSizeDefault)
         assert(model.modelPartition(partition).length === 47)
       }

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestTransaction.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestTransaction.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020 G-Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.co.gresearch.spark.dgraph.connector
+
+import com.google.protobuf.ByteString
+import io.dgraph.DgraphClient
+import io.dgraph.DgraphProto.Mutation
+import io.grpc.ManagedChannel
+import org.scalatest.FunSpec
+import uk.co.gresearch.spark.SparkTestSession
+import uk.co.gresearch.spark.dgraph.DgraphTestCluster
+import uk.co.gresearch.spark.dgraph.connector.sources.TestTriplesSource
+
+class TestTransaction extends FunSpec with SparkTestSession with DgraphTestCluster {
+
+  import spark.implicits._
+
+  // we want a fresh cluster that we can mutate, definitively not one that is always running and used by all tests
+  override val clusterAlwaysStartUp: Boolean = true
+
+  describe("Connector") {
+
+    def mutate(): Unit = {
+      val channels: Seq[ManagedChannel] = Seq(toChannel(Target(cluster.grpc)))
+      try {
+        val client: DgraphClient = getClientFromChannel(channels)
+
+        val mutationInsert = Mutation.newBuilder()
+          .setSetNquads(ByteString.copyFromUtf8(
+            s"""
+               |_:1 <dgraph.type> "Person" .
+               |_:1 <name> "Obi-Wan 'Ben' Kenobi" .
+               |<0x${sw1.toHexString}> <starring> _:1 .
+               |""".stripMargin
+          ))
+          .setCommitNow(true).build()
+
+        val mutationUpdate = Mutation.newBuilder()
+          .setSetNquads(ByteString.copyFromUtf8(
+            s"""<0x${leia.toHexString}> <name> "Princess Leia Organa" .""".stripMargin
+          ))
+          .setCommitNow(true).build()
+
+        val mutationDelete = Mutation.newBuilder()
+          .setDelNquads(ByteString.copyFromUtf8(
+            s"""<0x${sw1.toHexString}> <starring> <0x${leia.toHexString}> .""".stripMargin
+          ))
+          .setCommitNow(true).build()
+
+        val transactionInsert = client.newTransaction()
+        transactionInsert.mutate(mutationInsert)
+        transactionInsert.close()
+
+        val transactionUpdate = client.newTransaction()
+        transactionUpdate.mutate(mutationUpdate)
+        transactionUpdate.close()
+
+        val transactionDelete = client.newTransaction()
+        transactionDelete.mutate(mutationDelete)
+        transactionDelete.close()
+      } finally {
+        channels.foreach(_.shutdown())
+      }
+    }
+
+    it("should read in transaction") {
+      val before = spark.read.dgraphTriples(cluster.grpc)
+      val beforeTriples = before.as[TypedTriple].collect().toSet
+      assert(beforeTriples === TestTriplesSource.getExpectedTypedTriples(this))
+
+      mutate()
+      val afterBeforeTriples = before.as[TypedTriple].collect().toSet
+      assert(beforeTriples === afterBeforeTriples)
+
+      val after = spark.read.dgraphTriples(cluster.grpc)
+      val afterTriples = after.as[TypedTriple].collect().toSet
+
+      val expectedAfterTriples =
+        beforeTriples
+          // minus updated
+          .filterNot(t => t.subject == leia && t.predicate == "name")
+          // minus deleted
+          .filterNot(t => t.subject == sw1 && t.predicate == "starring" && t.objectUid.contains(leia)) ++
+          // plus
+          Seq(
+            // plus updated
+            beforeTriples
+              .find(t => t.subject == leia && t.predicate == "name")
+              .map(_.copy(objectString = Some("Princess Leia Organa")))
+              .get,
+            // plus insterted
+            TypedTriple(highestUid + 1, "dgraph.type", None, Some("Person"), None, None, None, None, None, None, "string"),
+            TypedTriple(highestUid + 1, "name", None, Some("Obi-Wan 'Ben' Kenobi"), None, None, None, None, None, None, "string"),
+            TypedTriple(sw1, "starring", Some(highestUid + 1), None, None, None, None, None, None, None, "uid")
+          ).toSet
+
+      assert(afterTriples !== beforeTriples)
+      assert(afterTriples === expectedAfterTriples)
+    }
+  }
+}

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestDefaultPartitionerOption.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestDefaultPartitionerOption.scala
@@ -18,9 +18,10 @@ package uk.co.gresearch.spark.dgraph.connector.partitioner
 
 import java.util.UUID
 
+import io.dgraph.DgraphProto.TxnContext
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.scalatest.FunSpec
-import uk.co.gresearch.spark.dgraph.connector.{ClusterState, Predicate, Schema, Target}
+import uk.co.gresearch.spark.dgraph.connector.{ClusterState, Predicate, Schema, Target, Transaction}
 
 class TestDefaultPartitionerOption extends FunSpec {
 
@@ -33,10 +34,11 @@ class TestDefaultPartitionerOption extends FunSpec {
       10000,
       UUID.randomUUID()
     )
+    val transaction = Transaction(TxnContext.newBuilder().build())
     val options = CaseInsensitiveStringMap.empty()
 
     it(s"should provide a partitioner") {
-      new DefaultPartitionerOption().getPartitioner(schema, state, options)
+      new DefaultPartitionerOption().getPartitioner(schema, state, transaction, options)
     }
   }
 }

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestTriplesSource.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestTriplesSource.scala
@@ -21,7 +21,7 @@ import java.sql.Timestamp
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Expression, In, Literal}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceRDDPartition
 import org.apache.spark.sql.types.StringType
-import org.apache.spark.sql.{Column, DataFrame, Dataset}
+import org.apache.spark.sql.{Column, DataFrame}
 import org.scalatest.FunSpec
 import uk.co.gresearch.spark.SparkTestSession
 import uk.co.gresearch.spark.dgraph.DgraphTestCluster
@@ -36,55 +36,7 @@ class TestTriplesSource extends FunSpec
 
   describe("TriplesDataSource") {
 
-    lazy val expectedTypedTriples = Set(
-      TypedTriple(graphQlSchema, "dgraph.type", None, Some("dgraph.graphql"), None, None, None, None, None, None, "string"),
-      TypedTriple(graphQlSchema, "dgraph.graphql.xid", None, Some("dgraph.graphql.schema"), None, None, None, None, None, None, "string"),
-      TypedTriple(graphQlSchema, "dgraph.graphql.schema", None, Some(""), None, None, None, None, None, None, "string"),
-      TypedTriple(st1, "dgraph.type", None, Some("Film"), None, None, None, None, None, None, "string"),
-      TypedTriple(st1, "name", None, Some("Star Trek: The Motion Picture"), None, None, None, None, None, None, "string"),
-      TypedTriple(st1, "release_date", None, None, None, None, Some(Timestamp.valueOf("1979-12-07 00:00:00.0")), None, None, None, "timestamp"),
-      TypedTriple(st1, "revenue", None, None, None, Some(1.39E8), None, None, None, None, "double"),
-      TypedTriple(st1, "running_time", None, None, Some(132), None, None, None, None, None, "long"),
-      TypedTriple(leia, "dgraph.type", None, Some("Person"), None, None, None, None, None, None, "string"),
-      TypedTriple(leia, "name", None, Some("Princess Leia"), None, None, None, None, None, None, "string"),
-      TypedTriple(lucas, "dgraph.type", None, Some("Person"), None, None, None, None, None, None, "string"),
-      TypedTriple(lucas, "name", None, Some("George Lucas"), None, None, None, None, None, None, "string"),
-      TypedTriple(irvin, "dgraph.type", None, Some("Person"), None, None, None, None, None, None, "string"),
-      TypedTriple(irvin, "name", None, Some("Irvin Kernshner"), None, None, None, None, None, None, "string"),
-      TypedTriple(sw1, "dgraph.type", None, Some("Film"), None, None, None, None, None, None, "string"),
-      TypedTriple(sw1, "director", Some(lucas), None, None, None, None, None, None, None, "uid"),
-      TypedTriple(sw1, "name", None, Some("Star Wars: Episode IV - A New Hope"), None, None, None, None, None, None, "string"),
-      TypedTriple(sw1, "release_date", None, None, None, None, Some(Timestamp.valueOf("1977-05-25 00:00:00.0")), None, None, None, "timestamp"),
-      TypedTriple(sw1, "revenue", None, None, None, Some(7.75E8), None, None, None, None, "double"),
-      TypedTriple(sw1, "running_time", None, None, Some(121), None, None, None, None, None, "long"),
-      TypedTriple(sw1, "starring", Some(leia), None, None, None, None, None, None, None, "uid"),
-      TypedTriple(sw1, "starring", Some(luke), None, None, None, None, None, None, None, "uid"),
-      TypedTriple(sw1, "starring", Some(han), None, None, None, None, None, None, None, "uid"),
-      TypedTriple(sw2, "dgraph.type", None, Some("Film"), None, None, None, None, None, None, "string"),
-      TypedTriple(sw2, "director", Some(irvin), None, None, None, None, None, None, None, "uid"),
-      TypedTriple(sw2, "name", None, Some("Star Wars: Episode V - The Empire Strikes Back"), None, None, None, None, None, None, "string"),
-      TypedTriple(sw2, "release_date", None, None, None, None, Some(Timestamp.valueOf("1980-05-21 00:00:00.0")), None, None, None, "timestamp"),
-      TypedTriple(sw2, "revenue", None, None, None, Some(5.34E8), None, None, None, None, "double"),
-      TypedTriple(sw2, "running_time", None, None, Some(124), None, None, None, None, None, "long"),
-      TypedTriple(sw2, "starring", Some(leia), None, None, None, None, None, None, None, "uid"),
-      TypedTriple(sw2, "starring", Some(luke), None, None, None, None, None, None, None, "uid"),
-      TypedTriple(sw2, "starring", Some(han), None, None, None, None, None, None, None, "uid"),
-      TypedTriple(luke, "dgraph.type", None, Some("Person"), None, None, None, None, None, None, "string"),
-      TypedTriple(luke, "name", None, Some("Luke Skywalker"), None, None, None, None, None, None, "string"),
-      TypedTriple(han, "dgraph.type", None, Some("Person"), None, None, None, None, None, None, "string"),
-      TypedTriple(han, "name", None, Some("Han Solo"), None, None, None, None, None, None, "string"),
-      TypedTriple(richard, "dgraph.type", None, Some("Person"), None, None, None, None, None, None, "string"),
-      TypedTriple(richard, "name", None, Some("Richard Marquand"), None, None, None, None, None, None, "string"),
-      TypedTriple(sw3, "dgraph.type", None, Some("Film"), None, None, None, None, None, None, "string"),
-      TypedTriple(sw3, "director", Some(richard), None, None, None, None, None, None, None, "uid"),
-      TypedTriple(sw3, "name", None, Some("Star Wars: Episode VI - Return of the Jedi"), None, None, None, None, None, None, "string"),
-      TypedTriple(sw3, "release_date", None, None, None, None, Some(Timestamp.valueOf("1983-05-25 00:00:00.0")), None, None, None, "timestamp"),
-      TypedTriple(sw3, "revenue", None, None, None, Some(5.72E8), None, None, None, None, "double"),
-      TypedTriple(sw3, "running_time", None, None, Some(131), None, None, None, None, None, "long"),
-      TypedTriple(sw3, "starring", Some(leia), None, None, None, None, None, None, None, "uid"),
-      TypedTriple(sw3, "starring", Some(luke), None, None, None, None, None, None, None, "uid"),
-      TypedTriple(sw3, "starring", Some(han), None, None, None, None, None, None, None, "uid"),
-    )
+    lazy val expectedTypedTriples = TestTriplesSource.getExpectedTypedTriples(this)
 
     def doTestLoadTypedTriples(load: () => DataFrame): Unit = {
       val triples = load().as[TypedTriple].collect().toSet
@@ -622,5 +574,60 @@ class TestTriplesSource extends FunSpec
     }
 
   }
+
+}
+
+object TestTriplesSource {
+
+  def getExpectedTypedTriples(cluster: DgraphTestCluster): Set[TypedTriple] =
+    Set(
+      TypedTriple(cluster.graphQlSchema, "dgraph.type", None, Some("dgraph.graphql"), None, None, None, None, None, None, "string"),
+      TypedTriple(cluster.graphQlSchema, "dgraph.graphql.xid", None, Some("dgraph.graphql.schema"), None, None, None, None, None, None, "string"),
+      TypedTriple(cluster.graphQlSchema, "dgraph.graphql.schema", None, Some(""), None, None, None, None, None, None, "string"),
+      TypedTriple(cluster.st1, "dgraph.type", None, Some("Film"), None, None, None, None, None, None, "string"),
+      TypedTriple(cluster.st1, "name", None, Some("Star Trek: The Motion Picture"), None, None, None, None, None, None, "string"),
+      TypedTriple(cluster.st1, "release_date", None, None, None, None, Some(Timestamp.valueOf("1979-12-07 00:00:00.0")), None, None, None, "timestamp"),
+      TypedTriple(cluster.st1, "revenue", None, None, None, Some(1.39E8), None, None, None, None, "double"),
+      TypedTriple(cluster.st1, "running_time", None, None, Some(132), None, None, None, None, None, "long"),
+      TypedTriple(cluster.leia, "dgraph.type", None, Some("Person"), None, None, None, None, None, None, "string"),
+      TypedTriple(cluster.leia, "name", None, Some("Princess Leia"), None, None, None, None, None, None, "string"),
+      TypedTriple(cluster.lucas, "dgraph.type", None, Some("Person"), None, None, None, None, None, None, "string"),
+      TypedTriple(cluster.lucas, "name", None, Some("George Lucas"), None, None, None, None, None, None, "string"),
+      TypedTriple(cluster.irvin, "dgraph.type", None, Some("Person"), None, None, None, None, None, None, "string"),
+      TypedTriple(cluster.irvin, "name", None, Some("Irvin Kernshner"), None, None, None, None, None, None, "string"),
+      TypedTriple(cluster.sw1, "dgraph.type", None, Some("Film"), None, None, None, None, None, None, "string"),
+      TypedTriple(cluster.sw1, "director", Some(cluster.lucas), None, None, None, None, None, None, None, "uid"),
+      TypedTriple(cluster.sw1, "name", None, Some("Star Wars: Episode IV - A New Hope"), None, None, None, None, None, None, "string"),
+      TypedTriple(cluster.sw1, "release_date", None, None, None, None, Some(Timestamp.valueOf("1977-05-25 00:00:00.0")), None, None, None, "timestamp"),
+      TypedTriple(cluster.sw1, "revenue", None, None, None, Some(7.75E8), None, None, None, None, "double"),
+      TypedTriple(cluster.sw1, "running_time", None, None, Some(121), None, None, None, None, None, "long"),
+      TypedTriple(cluster.sw1, "starring", Some(cluster.leia), None, None, None, None, None, None, None, "uid"),
+      TypedTriple(cluster.sw1, "starring", Some(cluster.luke), None, None, None, None, None, None, None, "uid"),
+      TypedTriple(cluster.sw1, "starring", Some(cluster.han), None, None, None, None, None, None, None, "uid"),
+      TypedTriple(cluster.sw2, "dgraph.type", None, Some("Film"), None, None, None, None, None, None, "string"),
+      TypedTriple(cluster.sw2, "director", Some(cluster.irvin), None, None, None, None, None, None, None, "uid"),
+      TypedTriple(cluster.sw2, "name", None, Some("Star Wars: Episode V - The Empire Strikes Back"), None, None, None, None, None, None, "string"),
+      TypedTriple(cluster.sw2, "release_date", None, None, None, None, Some(Timestamp.valueOf("1980-05-21 00:00:00.0")), None, None, None, "timestamp"),
+      TypedTriple(cluster.sw2, "revenue", None, None, None, Some(5.34E8), None, None, None, None, "double"),
+      TypedTriple(cluster.sw2, "running_time", None, None, Some(124), None, None, None, None, None, "long"),
+      TypedTriple(cluster.sw2, "starring", Some(cluster.leia), None, None, None, None, None, None, None, "uid"),
+      TypedTriple(cluster.sw2, "starring", Some(cluster.luke), None, None, None, None, None, None, None, "uid"),
+      TypedTriple(cluster.sw2, "starring", Some(cluster.han), None, None, None, None, None, None, None, "uid"),
+      TypedTriple(cluster.luke, "dgraph.type", None, Some("Person"), None, None, None, None, None, None, "string"),
+      TypedTriple(cluster.luke, "name", None, Some("Luke Skywalker"), None, None, None, None, None, None, "string"),
+      TypedTriple(cluster.han, "dgraph.type", None, Some("Person"), None, None, None, None, None, None, "string"),
+      TypedTriple(cluster.han, "name", None, Some("Han Solo"), None, None, None, None, None, None, "string"),
+      TypedTriple(cluster.richard, "dgraph.type", None, Some("Person"), None, None, None, None, None, None, "string"),
+      TypedTriple(cluster.richard, "name", None, Some("Richard Marquand"), None, None, None, None, None, None, "string"),
+      TypedTriple(cluster.sw3, "dgraph.type", None, Some("Film"), None, None, None, None, None, None, "string"),
+      TypedTriple(cluster.sw3, "director", Some(cluster.richard), None, None, None, None, None, None, None, "uid"),
+      TypedTriple(cluster.sw3, "name", None, Some("Star Wars: Episode VI - Return of the Jedi"), None, None, None, None, None, None, "string"),
+      TypedTriple(cluster.sw3, "release_date", None, None, None, None, Some(Timestamp.valueOf("1983-05-25 00:00:00.0")), None, None, None, "timestamp"),
+      TypedTriple(cluster.sw3, "revenue", None, None, None, Some(5.72E8), None, None, None, None, "double"),
+      TypedTriple(cluster.sw3, "running_time", None, None, Some(131), None, None, None, None, None, "long"),
+      TypedTriple(cluster.sw3, "starring", Some(cluster.leia), None, None, None, None, None, None, None, "uid"),
+      TypedTriple(cluster.sw3, "starring", Some(cluster.luke), None, None, None, None, None, None, None, "uid"),
+      TypedTriple(cluster.sw3, "starring", Some(cluster.han), None, None, None, None, None, None, None, "uid"),
+    )
 
 }


### PR DESCRIPTION
All partitions read within the same transaction. Also uid count estimation uses that transaction. Fixes issue #6.

This is blocked by a [upstream change to dgraph4j](https://github.com/dgraph-io/dgraph4j/pull/149).