### PR TITLE
Make predicate partitioner efficient with single predicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Load data from Dgraph cluster as [GraphFrames](https://graphframes.github.io/graphframes/docs/_site/index.html) `GraphFrame`.
 - Use exact uid cardinality for uid range partitioning. Combined with predicate partitioning, large
   predicates get split into more partitions than small predicates.
+- Improve performance of `PredicatePartitioner` for a single predicate per partition (`dgraph.partitioner.predicate.predicatesPerPartition=1`).
+  This becomes the new default for this partitioner.
 
 ### Fixed
 - Dgraph groups with no predicates caused a `NullPointerException`.

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/package.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/package.scala
@@ -114,7 +114,7 @@ package object connector {
   val AlphaPartitionerPartitionsOption: String = "dgraph.partitioner.alpha.partitionsPerAlpha"
   val AlphaPartitionerPartitionsDefault: Int = 1
   val PredicatePartitionerPredicatesOption: String = "dgraph.partitioner.predicate.predicatesPerPartition"
-  val PredicatePartitionerPredicatesDefault: Int = 1000
+  val PredicatePartitionerPredicatesDefault: Int = 1
   val UidRangePartitionerUidsPerPartOption: String = "dgraph.partitioner.uidRange.uidsPerPartition"
   val UidRangePartitionerUidsPerPartDefault: Int = 1000
   val UidRangePartitionerEstimatorOption: String = "dgraph.partitioner.uidRange.estimator"


### PR DESCRIPTION
Makes single predicate partitions the default for the `PredicatePartitioner`.
Removes alpha and group partitioner from `README.md`.