### PR TITLE
Make predicate partitioner efficient with multiple predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased] - YYYY-MM-DD
 
+### Added
+- Improve performance of `PredicatePartitioner` for multiple predicates per partition. Restoring
+  default number of predicates per partition of `1000` from before 0.3.0 ([issue #22](https://github.com/G-Research/spark-dgraph-connector/issues/22)).
+- The `PredicatePartitioner` combined with `UidRangePartitioner` is the default partitioner now,
+  except for loading wide nodes, which still uses `PredicatePartitioner` as the default.
+
 ### Security
 - Moved Google Guava dependency version fix to 24.1.1-jre due to [known security vulnerability
   fixed in 24.1.1](https://github.com/advisories/GHSA-mvr2-9pj6-7w5j)

--- a/README.md
+++ b/README.md
@@ -285,6 +285,9 @@ Note: The graph schema could become very large and therefore the `DataFrame` cou
 |9      |null                 |Person     |Richard Marquand                              |null               |null   |null        |
 |10     |null                 |Film       |Star Wars: Episode V - The Empire Strikes Back|1980-05-21 00:00:00|5.34E8 |124         |
 
+Note: Wide nodes do not work with predicate partitioner.
+Default partitioner for wide nodes is `UidRangePartitioner`.
+
 #### Edges
 
 Edges can be loaded as follows:
@@ -348,11 +351,19 @@ specific use case, try a more appropriate partitioning scheme.
 
 The following `Partitioner` implementations are available:
 
-| Partitioner             | partition by | Description | Use Case |
-|:-----------------------:|:------------:|-------------|----------|
-| Singleton               | _nothing_    | Provides a single partition for the entire graph. | Unit Tests and small graphs that fit into a single partition. Can be used for large graphs if combined with a "by uid" partitioner. |
-| Uid Range _(default)_   | uids         | Each partition has at most `N` uids where `N` defaults to `1000`. | Large graphs where single `uid`s fit into a partition. Can be combined with any "by predicate" partitioner, otherwise induces internal Dgraph cluster communication across groups. Combine with Predicate partitioner and set `P` to `1` if some uids do not fit into a partition. |
-| Predicate               | predicate    | Provides multiple partitions with at most `P` predicates per partition where `P` defaults to `1`. Partitions with multiple predicates perform poorly with large graphs ([issue #22](https://github.com/G-Research/spark-dgraph-connector/issues/22)). Picks multiple predicates from the same Dgraph group. | Graphs with a small number of different predicates (100s) or graphs with huge schema with only a few predicates actually selected ([issue #7](https://github.com/G-Research/spark-dgraph-connector/issues/7)). Each predicate should fit into one partition, otherwise combine with Uid Range partitioner. Skewness of predicates reflects skewness of partitions. |
+| Partitioner                       | partition by              | Description | Use Case |
+|:---------------------------------:|:-------------------------:|-------------|----------|
+| Singleton                         | _nothing_                 | Provides a single partition for the entire graph. | Unit Tests and small graphs that fit into a single partition. Can be used for large graphs if combined with a "by uid" partitioner. |
+| Predicate                         | predicate                 | Provides multiple partitions with at most `P` predicates per partition where `P` defaults to `1000`. Picks multiple predicates from the same Dgraph group. | Large graphs where each predicate fits into a partition, otherwise combine with Uid Range partitioner. Skewness of predicates reflects skewness of partitions. |
+| Uid Range                         | uids                      | Each partition has at most `N` uids where `N` defaults to `1000`. | Large graphs where single `uid`s fit into a partition. Can be combined with any "by predicate" partitioner, otherwise induces internal Dgraph cluster communication across groups. Combine with Predicate partitioner and set `P` to `1` if some uids do not fit into a partition. |
+| Predicate + Uid Range _(default)_ | predicates + uids         | Partitions by predicate first (see Predicate Partitioner), then each partition gets partitioned by uid (see Uid Partitioner) | Graphs of any size. |
+
+
+#### Partitioning by Predicates
+
+The Dgraph data can be partitioned by predicates. Each partition then contains a distinct set of predicates.
+Those partitions connect only to alpha nodes that contain those predicates. Hence, these reads are all
+locally to the alpha nodes and induce no Dgraph cluster internal communication.
 
 #### Partitioning by Uids
 
@@ -361,9 +372,9 @@ the graph by the subject of the graph triples. This can be combined with predica
 which serves as an orthogonal partitioning. Without predicate partitioning, `uid` partitioning
 induces internal Dgraph cluster communication across the groups.
 
-The uid partitioning is based on top of a predicate partitioner. If none is defined a singleton partitioner is used.
+The uid partitioning always works on top of a predicate partitioner. If none is defined a singleton partitioner is used.
 The number of uids of each underlying partition has to be estimated. Once the number of uids is estimated,
-the partition can further be split into ranges of that uid space.
+the partition is further split into ranges of that uid space.
 
 The space of existing `uids` is split into ranges of `N` `uids` per partition. The `N` defaults to `1000`
 and can be configured via `dgraph.partitioner.uidRange.uidsPerPartition`. The `uid`s are allocated to
@@ -380,14 +391,8 @@ This estimator can be selected with the `maxLeaseId` value.
 
 ##### Count Uid Estimator
 
-This estimator counts the distinct uids within each underlying partition first. With many or large predicate partitions, this can become expensive.
-The estimator is the default estimator for uid partitioning and can be selected with the `count` value.
-
-#### Partitioning by Predicates
-
-The Dgraph data can be partitioned by predicates. Each partition then contains a distinct set of predicates.
-Those partitions connect only to alpha nodes that contain those predicates. Hence, these reads are all
-locally to the alpha nodes and induce no Dgraph cluster internal communication.
+The count estimator counts the distinct uids within each underlying partition first. With many or large predicate partitions, this can become expensive.
+This estimator is the default estimator for uid partitioning and can be selected with the `count` value.
 
 ## Dependencies
 

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/package.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/package.scala
@@ -114,7 +114,7 @@ package object connector {
   val AlphaPartitionerPartitionsOption: String = "dgraph.partitioner.alpha.partitionsPerAlpha"
   val AlphaPartitionerPartitionsDefault: Int = 1
   val PredicatePartitionerPredicatesOption: String = "dgraph.partitioner.predicate.predicatesPerPartition"
-  val PredicatePartitionerPredicatesDefault: Int = 1
+  val PredicatePartitionerPredicatesDefault: Int = 1000
   val UidRangePartitionerUidsPerPartOption: String = "dgraph.partitioner.uidRange.uidsPerPartition"
   val UidRangePartitionerUidsPerPartDefault: Int = 1000
   val UidRangePartitionerEstimatorOption: String = "dgraph.partitioner.uidRange.estimator"

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/ConfigPartitionerOption.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/ConfigPartitionerOption.scala
@@ -31,7 +31,7 @@ class ConfigPartitionerOption extends PartitionerProviderOption
     getStringOption(PartitionerOption, options)
       .map(getPartitioner(_, schema, clusterState, options))
 
-  private def getPartitioner(partitionerName: String,
+  def getPartitioner(partitionerName: String,
                              schema: Schema,
                              clusterState: ClusterState,
                              options: CaseInsensitiveStringMap): Partitioner =

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/DefaultPartitionerOption.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/DefaultPartitionerOption.scala
@@ -20,19 +20,18 @@ package uk.co.gresearch.spark.dgraph.connector.partitioner
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import uk.co.gresearch.spark.dgraph.connector._
 
-class DefaultPartitionerOption extends ConfigParser
-  with PartitionerProviderOption with EstimatorProviderOption
-  with ClusterStateHelper {
+class DefaultPartitionerOption extends ConfigPartitionerOption {
+
+  // for wide nodes we use uid range partitioner, for all other sources we use predicate + uid range
+  val defaultPartitionerName = s"$PredicatePartitionerOption+$UidRangePartitionerOption"
+  val wideNodeDefaultPartitionerName = s"$UidRangePartitionerOption"
 
   override def getPartitioner(schema: Schema,
                               clusterState: ClusterState,
                               options: CaseInsensitiveStringMap): Option[Partitioner] =
-    Some(
-      UidRangePartitioner(
-        SingletonPartitioner(getAllClusterTargets(clusterState)),
-        getIntOption(UidRangePartitionerUidsPerPartOption, options, UidRangePartitionerUidsPerPartDefault),
-        getEstimatorOption(UidRangePartitionerEstimatorOption, options, UidRangePartitionerEstimatorDefault, clusterState)
-      )
-    )
+    if (getStringOption(NodesModeOption, options).contains(NodesModeWideOption))
+      Some(getPartitioner(wideNodeDefaultPartitionerName, schema, clusterState, options))
+    else
+      Some(getPartitioner(defaultPartitionerName, schema, clusterState, options))
 
 }

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/graphframes/package.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/graphframes/package.scala
@@ -18,9 +18,7 @@ package object graphframes {
 
   def loadVertices(reader: DataFrameReader, targets: String*): DataFrame = {
     val vertices =
-      DgraphDataFrameReader(
-        reader.option(NodesModeOption, NodesModeWideOption)
-      )
+      DgraphDataFrameReader(reader.option(NodesModeOption, NodesModeWideOption).option(PredicatePartitionerPredicatesOption, "1"))
         .dgraphNodes(targets.head, targets.tail: _*)
         .withColumnRenamed("subject", "id")
     val renamedColumns =

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestPartitionerProvider.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestPartitionerProvider.scala
@@ -75,16 +75,26 @@ class TestPartitionerProvider extends FunSpec {
       val provider = new PartitionerProvider {}
       val options = CaseInsensitiveStringMap.empty()
       val partitioner = provider.getPartitioner(schema, state, options)
-      assert(partitioner === UidRangePartitioner(SingletonPartitioner(target), UidRangePartitionerUidsPerPartDefault, queryEstimator))
+
+      val predicatePart = PredicatePartitioner(schema, state, PredicatePartitionerPredicatesDefault)
+      val expected = UidRangePartitioner(predicatePart, UidRangePartitionerUidsPerPartDefault, queryEstimator)
+      assert(partitioner === expected)
     }
 
     it("should provide configurable default partitioner") {
       val provider = new PartitionerProvider {}
       val options = new CaseInsensitiveStringMap(
-        Map(UidRangePartitionerUidsPerPartOption -> "1", UidRangePartitionerEstimatorOption -> MaxLeaseIdEstimatorOption).asJava
+        Map(
+          PredicatePartitionerPredicatesOption -> "1",
+          UidRangePartitionerUidsPerPartOption -> "2",
+          UidRangePartitionerEstimatorOption -> MaxLeaseIdEstimatorOption
+        ).asJava
       )
       val partitioner = provider.getPartitioner(schema, state, options)
-      assert(partitioner === UidRangePartitioner(SingletonPartitioner(target), 1, MaxLeaseIdUidCardinalityEstimator(state.maxLeaseId)))
+
+      val predicatePart = PredicatePartitioner(schema, state, 1)
+      val expected = UidRangePartitioner(predicatePart, 2, MaxLeaseIdUidCardinalityEstimator(state.maxLeaseId))
+      assert(partitioner === expected)
     }
 
     it("should fail on unknown partitioner option") {

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestNodeSource.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestNodeSource.scala
@@ -162,6 +162,18 @@ class TestNodeSource extends FunSpec
       )
     }
 
+    it("should not load wide nodes with predicate partitioner") {
+      assertThrows[IllegalArgumentException] {
+        spark
+          .read
+          .options(Map(
+            NodesModeOption -> NodesModeWideOption,
+            PartitionerOption -> PredicatePartitionerOption
+          ))
+          .dgraphNodes(cluster.grpc)
+      }
+    }
+
     it("should encode TypedNode") {
       val rows =
         spark
@@ -205,7 +217,6 @@ class TestNodeSource extends FunSpec
           case p: DataSourceRDDPartition => Some(p.inputPartition)
           case _ => None
         }
-      assert(partitions.length === 1)
       assert(partitions === Seq(Some(Partition(targets, None, None))))
     }
 
@@ -222,7 +233,6 @@ class TestNodeSource extends FunSpec
           case p: DataSourceRDDPartition => Some(p.inputPartition)
           case _ => None
         }
-      assert(partitions.length === 4)
       assert(partitions === Seq(
         Some(Partition(Seq(Target(cluster.grpc)), Some(Set(Predicate("release_date", "datetime"), Predicate("running_time", "int"))), None)),
         Some(Partition(Seq(Target(cluster.grpc)), Some(Set(Predicate("dgraph.graphql.schema", "string"), Predicate("name", "string"))), None)),
@@ -236,11 +246,13 @@ class TestNodeSource extends FunSpec
       val partitions =
         spark
           .read
-          .option(UidRangePartitionerUidsPerPartOption, "7")
+          .options(Map(
+            PartitionerOption -> UidRangePartitionerOption,
+            UidRangePartitionerUidsPerPartOption -> "7"
+          ))
           .dgraphNodes(target)
           .mapPartitions(part => Iterator(part.map(_.getLong(0)).toSet))
           .collect()
-      assert(partitions.length === 2)
       assert(partitions === Seq((1 to 7).toSet, (8 to 10).toSet))
     }
 

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestTriplesSource.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestTriplesSource.scala
@@ -217,7 +217,6 @@ class TestTriplesSource extends FunSpec
           case p: DataSourceRDDPartition => Some(p.inputPartition)
           case _ => None
         }
-      assert(partitions.length === 1)
       assert(partitions === Seq(Some(Partition(targets, None, None))))
     }
 
@@ -234,7 +233,6 @@ class TestTriplesSource extends FunSpec
           case p: DataSourceRDDPartition => Some(p.inputPartition)
           case _ => None
         }
-      assert(partitions.length === 4)
       assert(partitions === Seq(
         Some(Partition(Seq(Target(cluster.grpc)), Some(Set(Predicate("release_date", "datetime"), Predicate("revenue", "float"))), None)),
         Some(Partition(Seq(Target(cluster.grpc)), Some(Set(Predicate("dgraph.graphql.schema", "string"), Predicate("starring", "uid"))), None)),
@@ -262,7 +260,6 @@ class TestTriplesSource extends FunSpec
         Some(Partition(Seq(Target(cluster.grpc)), None, Some(UidRange(7, 7)))),
       )
 
-      assert(partitions.length === expected.size)
       assert(partitions === expected)
     }
 
@@ -289,7 +286,6 @@ class TestTriplesSource extends FunSpec
         Some(Partition(Seq(Target(cluster.grpc)), Some(Set(Predicate("dgraph.type", "string"), Predicate("name", "string"))), Some(UidRange(5, 5))))
       )
 
-      assert(partitions.length === expected.size)
       assert(partitions === expected)
     }
 
@@ -298,11 +294,13 @@ class TestTriplesSource extends FunSpec
       val partitions =
         spark
           .read
-          .option(UidRangePartitionerUidsPerPartOption, "7")
+          .options(Map(
+            PartitionerOption -> UidRangePartitionerOption,
+            UidRangePartitionerUidsPerPartOption -> "7"
+          ))
           .dgraphTriples(target)
           .mapPartitions(part => Iterator(part.map(_.getLong(0)).toSet))
           .collect()
-      assert(partitions.length === 2)
       assert(partitions === Seq((1 to 7).toSet, (8 to 10).toSet))
     }
 


### PR DESCRIPTION
Reset default predicates per partition to 1000.

Fixes #22.