### PR TITLE
Wide nodes can be loaded with predicate partitioner

### DIFF
--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/sources/NodeSource.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/sources/NodeSource.scala
@@ -50,9 +50,9 @@ class NodeSource() extends TableProviderBase
       }
 
       new CaseInsensitiveStringMap(
-        (options.asScala.filterKeys(!_.equals(PredicatePartitionerPredicatesOption)) ++
+        (options.asScala.filterKeys(!_.equalsIgnoreCase(PredicatePartitionerPredicatesOption)) ++
           Map(PredicatePartitionerPredicatesOption -> Int.MaxValue.toString)
-          ).toMap.asJava
+          ).asJava
       )
     } else {
       options

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/sources/NodeSource.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/sources/NodeSource.scala
@@ -28,25 +28,44 @@ import uk.co.gresearch.spark.dgraph.connector.encoder.{TypedNodeEncoder, WideNod
 import uk.co.gresearch.spark.dgraph.connector.executor.DgraphExecutorProvider
 import uk.co.gresearch.spark.dgraph.connector.model.NodeTableModel
 import uk.co.gresearch.spark.dgraph.connector.partitioner.PartitionerProvider
+import scala.collection.JavaConverters._
 
 class NodeSource() extends TableProviderBase
   with TargetsConfigParser with SchemaProvider
   with ClusterStateProvider with PartitionerProvider {
 
-  def assertOptions(options: CaseInsensitiveStringMap): Unit = {
+  /**
+   * Sets the number of predicates per partition to max int when predicate partitioner is used
+   * in conjunction with wide node mode. Otherwise wide nodes cannot be properly loaded.
+   *
+   * @param options original options
+   * @return modified options
+   */
+  def adjustOptions(options: CaseInsensitiveStringMap): CaseInsensitiveStringMap = {
     if (getStringOption(NodesModeOption, options).contains(NodesModeWideOption) &&
-      getStringOption(PartitionerOption, options).contains(PredicatePartitionerOption)) {
-      throw new IllegalArgumentException("wide nodes cannot be read with predicate partitioner")
+      getStringOption(PartitionerOption, options).exists(_.startsWith(PredicatePartitionerOption))) {
+
+      if (getIntOption(PredicatePartitionerPredicatesOption, options).exists(_ != PredicatePartitionerPredicatesDefault)) {
+        println("WARN: predicate partitioner enforced to a single partition to support wide node source")
+      }
+
+      new CaseInsensitiveStringMap(
+        (options.asScala.filterKeys(!_.equals(PredicatePartitionerPredicatesOption)) ++
+          Map(PredicatePartitionerPredicatesOption -> Int.MaxValue.toString)
+          ).toMap.asJava
+      )
+    } else {
+      options
     }
   }
 
   override def shortName(): String = "dgraph-nodes"
 
   override def inferSchema(options: CaseInsensitiveStringMap): StructType = {
-    assertOptions(options)
-    val targets = getTargets(options)
+    val adjustedOptions = adjustOptions(options)
+    val targets = getTargets(adjustedOptions)
     val schema = getSchema(targets).filter(_.typeName != "uid")
-    getNodeMode(options) match {
+    getNodeMode(adjustedOptions) match {
       case Some(NodesModeTypedOption) => TypedNodeEncoder.schema()
       case Some(NodesModeWideOption) => WideNodeEncoder.schema(schema.predicateMap)
       case Some(mode) => throw new IllegalArgumentException(s"Unknown node mode: ${mode}")
@@ -61,13 +80,13 @@ class NodeSource() extends TableProviderBase
                         partitioning: Array[Transform],
                         properties: util.Map[String, String]): Table = {
     val options = new CaseInsensitiveStringMap(properties)
-    assertOptions(options)
+    val adjustedOptions = adjustOptions(options)
 
-    val targets = getTargets(options)
+    val targets = getTargets(adjustedOptions)
     val schema = getSchema(targets).filter(_.typeName != "uid")
     val clusterState = getClusterState(targets)
-    val partitioner = getPartitioner(schema, clusterState, options)
-    val nodeMode = getNodeMode(options)
+    val partitioner = getPartitioner(schema, clusterState, adjustedOptions)
+    val nodeMode = getNodeMode(adjustedOptions)
     val encoder = nodeMode match {
       case Some(NodesModeTypedOption) => TypedNodeEncoder(schema.predicateMap)
       case Some(NodesModeWideOption) => WideNodeEncoder(schema.predicateMap)
@@ -75,7 +94,7 @@ class NodeSource() extends TableProviderBase
       case None => TypedNodeEncoder(schema.predicateMap)
     }
     val execution = DgraphExecutorProvider()
-    val chunkSize = getIntOption(ChunkSizeOption, options)
+    val chunkSize = getIntOption(ChunkSizeOption, adjustedOptions)
     val model = NodeTableModel(execution, encoder, chunkSize)
     new TripleTable(partitioner, model, clusterState.cid)
   }

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestNodeSource.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestNodeSource.scala
@@ -165,16 +165,31 @@ class TestNodeSource extends FunSpec
       )
     }
 
-    it("should not load wide nodes with predicate partitioner") {
-      assertThrows[IllegalArgumentException] {
+    it("should load wide nodes with a single predicate partition") {
+      doTestLoadWideNodes(() =>
         spark
           .read
           .options(Map(
             NodesModeOption -> NodesModeWideOption,
-            PartitionerOption -> PredicatePartitionerOption
+            PartitionerOption -> PredicatePartitionerOption,
+            PredicatePartitionerPredicatesOption -> PredicatePartitionerPredicatesDefault.toString
           ))
           .dgraphNodes(cluster.grpc)
-      }
+      )
+    }
+
+    it("should load wide nodes with a single predicate partition and uid ranges") {
+      doTestLoadWideNodes(() =>
+        spark
+          .read
+          .options(Map(
+            NodesModeOption -> NodesModeWideOption,
+            PartitionerOption -> s"$PredicatePartitionerOption+$UidRangePartitionerOption",
+            PredicatePartitionerPredicatesOption -> PredicatePartitionerPredicatesDefault.toString,
+            UidRangePartitionerUidsPerPartOption -> "3"
+          ))
+          .dgraphNodes(cluster.grpc)
+      )
     }
 
     it("should load typed nodes in chunks") {

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestNodeSource.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestNodeSource.scala
@@ -165,28 +165,28 @@ class TestNodeSource extends FunSpec
       )
     }
 
-    it("should load wide nodes with a single predicate partition") {
+    it("should load wide nodes with predicate partitioner") {
       doTestLoadWideNodes(() =>
         spark
           .read
           .options(Map(
             NodesModeOption -> NodesModeWideOption,
             PartitionerOption -> PredicatePartitionerOption,
-            PredicatePartitionerPredicatesOption -> PredicatePartitionerPredicatesDefault.toString
+            PredicatePartitionerPredicatesOption -> "1"
           ))
           .dgraphNodes(cluster.grpc)
       )
     }
 
-    it("should load wide nodes with a single predicate partition and uid ranges") {
+    it("should load wide nodes with predicate partitioner and uid ranges") {
       doTestLoadWideNodes(() =>
         spark
           .read
           .options(Map(
             NodesModeOption -> NodesModeWideOption,
             PartitionerOption -> s"$PredicatePartitionerOption+$UidRangePartitionerOption",
-            PredicatePartitionerPredicatesOption -> PredicatePartitionerPredicatesDefault.toString,
-            UidRangePartitionerUidsPerPartOption -> "3"
+            PredicatePartitionerPredicatesOption -> "1",
+            UidRangePartitionerUidsPerPartOption -> "1"
           ))
           .dgraphNodes(cluster.grpc)
       )


### PR DESCRIPTION
Enforces a single predicate partition (per group), ignores predicates per partition option