### PR TITLE
Make Uid Range Partitioner use after, removes offset usage

### DIFF
--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/executor/DgraphExecutor.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/executor/DgraphExecutor.scala
@@ -17,7 +17,6 @@ case class DgraphExecutor(targets: Seq[Target]) extends JsonGraphQlExecutor {
     val channels: Seq[ManagedChannel] = targets.map(toChannel)
     try {
       val client: DgraphClient = getClientFromChannel(channels)
-      println(query.string)
       val response: Response = client.newReadOnlyTransaction().query(query.string)
       Json(response.getJson.toStringUtf8)
     } catch {

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/executor/DgraphExecutor.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/executor/DgraphExecutor.scala
@@ -17,6 +17,7 @@ case class DgraphExecutor(targets: Seq[Target]) extends JsonGraphQlExecutor {
     val channels: Seq[ManagedChannel] = targets.map(toChannel)
     try {
       val client: DgraphClient = getClientFromChannel(channels)
+      println(query.string)
       val response: Response = client.newReadOnlyTransaction().query(query.string)
       Json(response.getJson.toStringUtf8)
     } catch {

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/model/ChunkIterator.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/model/ChunkIterator.scala
@@ -1,14 +1,15 @@
 package uk.co.gresearch.spark.dgraph.connector.model
 
-import com.google.gson.JsonArray
+import com.google.gson.{JsonArray, JsonElement}
 import uk.co.gresearch.spark.dgraph.connector.{Chunk, Uid}
+import uk.co.gresearch.spark.dgraph.connector.model.ChunkIterator.getLastUid
 
-case class ChunkIterator(chunkSize: Int, readChunk: Chunk => JsonArray) extends Iterator[JsonArray] {
+case class ChunkIterator(after: Uid, chunkSize: Int, readChunk: Chunk => JsonArray) extends Iterator[JsonArray] {
 
   if (chunkSize <= 0)
     throw new IllegalArgumentException(s"Chunk size must be larger than zero: $chunkSize")
 
-  var nextChunk: Option[Chunk] = Some(Chunk(Uid("0x0"), chunkSize))
+  var nextChunk: Option[Chunk] = Some(Chunk(after, chunkSize))
   var nextValue: JsonArray = _
 
   // read first chunk
@@ -23,7 +24,7 @@ case class ChunkIterator(chunkSize: Int, readChunk: Chunk => JsonArray) extends 
       nextValue = readChunk(nextChunk.get)
       nextChunk =
         if (nextValue.size() >= nextChunk.get.length) {
-          Some(nextChunk.get.copy(after = getLastUid(nextValue)))
+          Some(nextChunk.get.withAfter(getLastUid(nextValue)))
         } else {
           None
         }
@@ -35,14 +36,10 @@ case class ChunkIterator(chunkSize: Int, readChunk: Chunk => JsonArray) extends 
     value
   }
 
-  /**
-   * Extracts the uid of the last element of the Json array.
-   * @param array Json array
-   * @return uid of the last element
-   */
-  private def getLastUid(array: JsonArray): Uid = {
-    val uidString = array.get(array.size()-1).getAsJsonObject.get("uid").getAsString
-    Uid(uidString)
-  }
+}
 
+object ChunkIterator {
+  def getLastUid(array: JsonArray): Uid = getUid(array.get(array.size() - 1))
+
+  def getUid(element: JsonElement): Uid = Uid(element.getAsJsonObject.get("uid").getAsString)
 }

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/model/EdgeTableModel.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/model/EdgeTableModel.scala
@@ -1,13 +1,13 @@
 package uk.co.gresearch.spark.dgraph.connector.model
-import uk.co.gresearch.spark.dgraph.connector
-import uk.co.gresearch.spark.dgraph.connector.{Chunk, GraphQl, PartitionQuery}
+
 import uk.co.gresearch.spark.dgraph.connector.encoder.TripleEncoder
 import uk.co.gresearch.spark.dgraph.connector.executor.ExecutorProvider
+import uk.co.gresearch.spark.dgraph.connector.{Chunk, GraphQl, PartitionQuery}
 
 /**
  * Models only the edges of a graph as a table.
  */
-case class EdgeTableModel(execution: ExecutorProvider, encoder: TripleEncoder, chunkSize: Option[Int]) extends GraphTableModel {
+case class EdgeTableModel(execution: ExecutorProvider, encoder: TripleEncoder, chunkSize: Int) extends GraphTableModel {
 
   /**
    * Turn a partition query into a GraphQl query.

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/model/NodeTableModel.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/model/NodeTableModel.scala
@@ -1,13 +1,13 @@
 package uk.co.gresearch.spark.dgraph.connector.model
-import uk.co.gresearch.spark.dgraph.connector
-import uk.co.gresearch.spark.dgraph.connector.{Chunk, GraphQl, PartitionQuery}
-import uk.co.gresearch.spark.dgraph.connector.encoder.InternalRowEncoder
+
+import uk.co.gresearch.spark.dgraph.connector.encoder.JsonNodeInternalRowEncoder
 import uk.co.gresearch.spark.dgraph.connector.executor.ExecutorProvider
+import uk.co.gresearch.spark.dgraph.connector.{Chunk, GraphQl, PartitionQuery}
 
 /**
  * Models only the nodes of a graph as a table.
  */
-case class NodeTableModel(execution: ExecutorProvider, encoder: InternalRowEncoder, chunkSize: Option[Int]) extends GraphTableModel {
+case class NodeTableModel(execution: ExecutorProvider, encoder: JsonNodeInternalRowEncoder, chunkSize: Int) extends GraphTableModel {
 
   /**
    * Turn a partition query into a GraphQl query.

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/model/TripleTableModel.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/model/TripleTableModel.scala
@@ -1,13 +1,13 @@
 package uk.co.gresearch.spark.dgraph.connector.model
-import uk.co.gresearch.spark.dgraph.connector
-import uk.co.gresearch.spark.dgraph.connector.{Chunk, GraphQl, PartitionQuery}
-import uk.co.gresearch.spark.dgraph.connector.encoder.InternalRowEncoder
+
+import uk.co.gresearch.spark.dgraph.connector.encoder.JsonNodeInternalRowEncoder
 import uk.co.gresearch.spark.dgraph.connector.executor.ExecutorProvider
+import uk.co.gresearch.spark.dgraph.connector.{Chunk, GraphQl, PartitionQuery}
 
 /**
  * Models all triples of a graph as a table, nodes with properties and edges.
  */
-case class TripleTableModel(execution: ExecutorProvider, encoder: InternalRowEncoder, chunkSize: Option[Int]) extends GraphTableModel {
+case class TripleTableModel(execution: ExecutorProvider, encoder: JsonNodeInternalRowEncoder, chunkSize: Int) extends GraphTableModel {
 
   /**
    * Turn a partition query into a GraphQl query.

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/package.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/package.scala
@@ -109,6 +109,13 @@ package object connector {
      * @return chunk with new after
      */
     def withAfter(after: Uid): Chunk = copy(after = after)
+
+    /**
+     * Returns a new Chunk with the same after but given length.
+     * @param length length
+     * @return chunk with new length
+     */
+    def withLength(length: Long): Chunk = copy(length = length)
   }
 
   // typed strings

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/DefaultPartitionerOption.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/DefaultPartitionerOption.scala
@@ -22,11 +22,9 @@ import uk.co.gresearch.spark.dgraph.connector._
 
 class DefaultPartitionerOption extends ConfigPartitionerOption {
 
-  val defaultPartitionerName = s"$PredicatePartitionerOption+$UidRangePartitionerOption"
-
   override def getPartitioner(schema: Schema,
                               clusterState: ClusterState,
                               options: CaseInsensitiveStringMap): Option[Partitioner] =
-    Some(getPartitioner(defaultPartitionerName, schema, clusterState, options))
+    Some(getPartitioner(PartitionerDefault, schema, clusterState, options))
 
 }

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/EstimatorProviderOption.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/EstimatorProviderOption.scala
@@ -1,8 +1,7 @@
 package uk.co.gresearch.spark.dgraph.connector.partitioner
 
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
-import uk.co.gresearch.spark.dgraph.connector.executor.DgraphExecutor
-import uk.co.gresearch.spark.dgraph.connector.{ClusterState, ConfigParser, MaxLeaseIdEstimatorOption, UidCountEstimatorOption}
+import uk.co.gresearch.spark.dgraph.connector._
 
 trait EstimatorProviderOption extends ConfigParser with ClusterStateHelper {
 
@@ -10,8 +9,10 @@ trait EstimatorProviderOption extends ConfigParser with ClusterStateHelper {
                          clusterState: ClusterState): UidCardinalityEstimator = {
     val name = getStringOption(option, options, default)
     name match {
-      case MaxLeaseIdEstimatorOption => UidCardinalityEstimator.forMaxLeaseId(clusterState.maxLeaseId)
-      case UidCountEstimatorOption => UidCardinalityEstimator.forExecutor(new DgraphExecutor(getAllClusterTargets(clusterState)))
+      case MaxLeaseIdEstimatorOption =>
+        val maxLeaseId = getIntOption(MaxLeaseIdEstimatorIdOption, options).map(_.toLong)
+        maxLeaseId.foreach(id => println(s"WARN: using configured maxLeaseId=$id for uid cardinality estimator"))
+        UidCardinalityEstimator.forMaxLeaseId(maxLeaseId.getOrElse(clusterState.maxLeaseId))
       case _ => throw new IllegalArgumentException(s"Unknown uid cardinality estimator: $name")
     }
   }

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/sources/EdgeSource.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/sources/EdgeSource.scala
@@ -27,7 +27,7 @@ import uk.co.gresearch.spark.dgraph.connector.encoder.EdgeEncoder
 import uk.co.gresearch.spark.dgraph.connector.executor.DgraphExecutorProvider
 import uk.co.gresearch.spark.dgraph.connector.model.EdgeTableModel
 import uk.co.gresearch.spark.dgraph.connector.partitioner.PartitionerProvider
-import uk.co.gresearch.spark.dgraph.connector.{ChunkSizeOption, ClusterStateProvider, SchemaProvider, TableProviderBase, TargetsConfigParser, TripleTable}
+import uk.co.gresearch.spark.dgraph.connector._
 
 class EdgeSource() extends TableProviderBase
   with TargetsConfigParser with SchemaProvider
@@ -48,7 +48,7 @@ class EdgeSource() extends TableProviderBase
     val partitioner = getPartitioner(schema, clusterState, options)
     val encoder = EdgeEncoder(schema.predicateMap)
     val execution = DgraphExecutorProvider()
-    val chunkSize = getIntOption(ChunkSizeOption, options)
+    val chunkSize = getIntOption(ChunkSizeOption, options, ChunkSizeDefault)
     val model = EdgeTableModel(execution, encoder, chunkSize)
     new TripleTable(partitioner, model, clusterState.cid)
   }

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/sources/NodeSource.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/sources/NodeSource.scala
@@ -93,7 +93,7 @@ class NodeSource() extends TableProviderBase
       case None => TypedNodeEncoder(schema.predicateMap)
     }
     val execution = DgraphExecutorProvider()
-    val chunkSize = getIntOption(ChunkSizeOption, adjustedOptions)
+    val chunkSize = getIntOption(ChunkSizeOption, adjustedOptions, ChunkSizeDefault)
     val model = NodeTableModel(execution, encoder, chunkSize)
     new TripleTable(partitioner, model, clusterState.cid)
   }

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/sources/TripleSource.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/sources/TripleSource.scala
@@ -62,7 +62,7 @@ class TripleSource() extends TableProviderBase
       case None => TypedTripleEncoder(schema.predicateMap)
     }
     val execution = DgraphExecutorProvider()
-    val chunkSize = getIntOption(ChunkSizeOption, options)
+    val chunkSize = getIntOption(ChunkSizeOption, options, ChunkSizeDefault)
     val model = TripleTableModel(execution, encoder, chunkSize)
     new TripleTable(partitioner, model, clusterState.cid)
   }

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestConnector.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestConnector.scala
@@ -42,9 +42,8 @@ class TestConnector extends FunSpec {
     }
 
     it("should validate UidRange") {
-      assertThrows[IllegalArgumentException]{ UidRange(-1, 1000) }
-      assertThrows[IllegalArgumentException]{ UidRange(0, 0) }
-      assertThrows[IllegalArgumentException]{ UidRange(0, -1) }
+      assertThrows[IllegalArgumentException]{ UidRange(Uid(1), Uid(1)) }
+      assertThrows[IllegalArgumentException]{ UidRange(Uid(2), Uid(1)) }
     }
 
     it("should validate Chunk") {

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestPartition.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestPartition.scala
@@ -42,7 +42,7 @@ class TestPartition extends FunSpec with SchemaProvider with DgraphTestCluster {
         val partition = Partition(targets, Option(schema.predicates), None)
         val encoder = TypedTripleEncoder(schema.predicateMap)
         val execution = DgraphExecutorProvider()
-        val model = TripleTableModel(execution, encoder, None)
+        val model = TripleTableModel(execution, encoder, ChunkSizeDefault)
         assert(model.modelPartition(partition).length === 47)
       }
 

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestPartitionQuery.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestPartitionQuery.scala
@@ -34,7 +34,7 @@ class TestPartitionQuery extends FunSpec {
     )
 
     it("should provide query for one property") {
-      val query = PartitionQuery("result", Some(prop), None)
+      val query = PartitionQuery("result", Some(prop))
       assert(query.forProperties(None).string ===
         """{
           |  pred1 as var(func: has(<prop>))
@@ -47,7 +47,7 @@ class TestPartitionQuery extends FunSpec {
     }
 
     it("should provide query for one property given edge") {
-      val query = PartitionQuery("result", Some(edge), None)
+      val query = PartitionQuery("result", Some(edge))
       assert(query.forProperties(None).string ===
         """{
           |  pred1 as var(func: has(<edge>))
@@ -60,7 +60,7 @@ class TestPartitionQuery extends FunSpec {
     }
 
     it("should provide query for one property or edge") {
-      val query1 = PartitionQuery("result", Some(prop), None)
+      val query1 = PartitionQuery("result", Some(prop))
       assert(query1.forProperties(None).string ===
         """{
           |  pred1 as var(func: has(<prop>))
@@ -71,7 +71,7 @@ class TestPartitionQuery extends FunSpec {
           |  }
           |}""".stripMargin)
 
-      val query2 = PartitionQuery("result", Some(edge), None)
+      val query2 = PartitionQuery("result", Some(edge))
       assert(query2.forProperties(None).string ===
         """{
           |  pred1 as var(func: has(<edge>))
@@ -84,7 +84,7 @@ class TestPartitionQuery extends FunSpec {
     }
 
     it("should provide query for all properties") {
-      val query = PartitionQuery("result", None, None)
+      val query = PartitionQuery("result", None)
       assert(query.forProperties(None).string ===
         """{
           |  result (func: has(dgraph.type)) {
@@ -96,7 +96,7 @@ class TestPartitionQuery extends FunSpec {
     }
 
     it("should provide query for some properties") {
-      val query = PartitionQuery("result", Some(predicates), None)
+      val query = PartitionQuery("result", Some(predicates))
       assert(query.forProperties(None).string ===
         """{
           |  pred1 as var(func: has(<prop1>))
@@ -114,22 +114,9 @@ class TestPartitionQuery extends FunSpec {
           |}""".stripMargin)
     }
 
-    it("should provide query for all properties with uid range") {
-      val uids = UidRange(1000, 500)
-      val query = PartitionQuery("result", None, Some(uids))
-      assert(query.forProperties(None).string ===
-        """{
-          |  result (func: has(dgraph.type), first: 500, offset: 1000) {
-          |    uid
-          |    dgraph.type
-          |    expand(_all_)
-          |  }
-          |}""".stripMargin)
-    }
-
     it("should provide query for properties with chunk") {
       val chunk = Chunk(Uid("0x123"), 10)
-      val query = PartitionQuery("result", Some(prop), None)
+      val query = PartitionQuery("result", Some(prop))
       assert(query.forProperties(Some(chunk)).string ===
         """{
           |  pred1 as var(func: has(<prop>), first: 10, after: 0x123)
@@ -143,7 +130,7 @@ class TestPartitionQuery extends FunSpec {
 
     it("should provide query for all properties with chunk") {
       val chunk = Chunk(Uid("0x123"), 10)
-      val query = PartitionQuery("result", None, None)
+      val query = PartitionQuery("result", None)
       assert(query.forProperties(Some(chunk)).string ===
         """{
           |  result (func: has(dgraph.type), first: 10, after: 0x123) {
@@ -157,7 +144,7 @@ class TestPartitionQuery extends FunSpec {
 
     it("should provide query for properties and edges with chunk") {
       val chunk = Chunk(Uid("0x123"), 10)
-      val query = PartitionQuery("result", Some(predicates), None)
+      val query = PartitionQuery("result", Some(predicates))
       assert(query.forPropertiesAndEdges(Some(chunk)).string ===
         """{
           |  pred1 as var(func: has(<prop1>), first: 10, after: 0x123)
@@ -177,7 +164,7 @@ class TestPartitionQuery extends FunSpec {
 
     it("should provide query for all properties and edges with chunk") {
       val chunk = Chunk(Uid("0x123"), 10)
-      val query = PartitionQuery("result", None, None)
+      val query = PartitionQuery("result", None)
       assert(query.forPropertiesAndEdges(Some(chunk)).string ===
         """{
           |  result (func: has(dgraph.type), first: 10, after: 0x123) {
@@ -191,7 +178,7 @@ class TestPartitionQuery extends FunSpec {
     }
 
     it("should provide query for all properties and edges") {
-      val query = PartitionQuery("result", None, None)
+      val query = PartitionQuery("result", None)
       assert(query.forPropertiesAndEdges(None).string ===
         """{
           |  result (func: has(dgraph.type)) {
@@ -204,23 +191,8 @@ class TestPartitionQuery extends FunSpec {
           |}""".stripMargin)
     }
 
-    it("should provide query for all properties and edges with uid range") {
-      val uids = UidRange(1000, 500)
-      val query = PartitionQuery("result", None, Some(uids))
-      assert(query.forPropertiesAndEdges(None).string ===
-        """{
-          |  result (func: has(dgraph.type), first: 500, offset: 1000) {
-          |    uid
-          |    dgraph.type
-          |    expand(_all_) {
-          |      uid
-          |    }
-          |  }
-          |}""".stripMargin)
-    }
-
     it("should provide query for some properties and edges") {
-      val query = PartitionQuery("result", Some(predicates), None)
+      val query = PartitionQuery("result", Some(predicates))
       assert(query.forPropertiesAndEdges(None).string ===
         """{
           |  pred1 as var(func: has(<prop1>))
@@ -239,7 +211,7 @@ class TestPartitionQuery extends FunSpec {
     }
 
     it("should provide query for one properties or edge") {
-      val query1 = PartitionQuery("result", Some(prop), None)
+      val query1 = PartitionQuery("result", Some(prop))
       assert(query1.forPropertiesAndEdges(None).string ===
         """{
           |  pred1 as var(func: has(<prop>))
@@ -250,7 +222,7 @@ class TestPartitionQuery extends FunSpec {
           |  }
           |}""".stripMargin)
 
-      val query2 = PartitionQuery("result", Some(edge), None)
+      val query2 = PartitionQuery("result", Some(edge))
       assert(query2.forPropertiesAndEdges(None).string ===
         """{
           |  pred1 as var(func: has(<edge>))
@@ -262,104 +234,35 @@ class TestPartitionQuery extends FunSpec {
           |}""".stripMargin)
     }
 
-    it("should provide query for some properties and edges with uid range") {
-      val uids = UidRange(1000, 500)
-      val query = PartitionQuery("result", Some(predicates), Some(uids))
-      assert(query.forPropertiesAndEdges(None).string ===
-        """{
-          |  pred1 as var(func: has(<prop1>))
-          |  pred2 as var(func: has(<prop2>))
-          |  pred3 as var(func: has(<edge1>))
-          |  pred4 as var(func: has(<edge2>))
-          |
-          |  result (func: uid(pred1,pred2,pred3,pred4), first: 500, offset: 1000) {
-          |    uid
-          |    <prop1>
-          |    <prop2>
-          |    <edge1> { uid }
-          |    <edge2> { uid }
-          |  }
-          |}""".stripMargin)
-    }
-
     it("should provide query for explicitly no properties and edges") {
-      val query = PartitionQuery("result", Some(Set.empty), None)
+      val query = PartitionQuery("result", Some(Set.empty))
       assert(query.forPropertiesAndEdges(None).string ===
         """{
           |  result (func: uid()) {
           |    uid
-          |  }
-          |}""".stripMargin)
-    }
-
-    it("should provide query to count all uids") {
-      val query = PartitionQuery("result", None, None)
-      assert(query.countUids.string ===
-        """{
-          |  result (func: has(dgraph.type)) {
-          |    count(uid)
-          |  }
-          |}""".stripMargin)
-    }
-
-    it("should provide query to count all uids with empty predicates") {
-      val query = PartitionQuery("result", Some(Set.empty), None)
-      assert(query.countUids.string ===
-        """{
-          |  result (func: uid()) {
-          |    count(uid)
-          |  }
-          |}""".stripMargin)
-    }
-
-    it("should provide query to count all uids with one predicate") {
-      Seq(prop, edge).foreach { preds =>
-        val query = PartitionQuery("result", Some(preds), None)
-        assert(query.countUids.string ===
-          s"""{
-             |  pred1 as var(func: has(<${preds.head.predicateName}>))
-             |
-             |  result (func: uid(pred1)) {
-             |    count(uid)
-             |  }
-             |}""".stripMargin)
-      }
-    }
-
-    it("should provide query to count all uids with some predicates") {
-      val query = PartitionQuery("result", Some(predicates), None)
-      assert(query.countUids.string ===
-        """{
-          |  pred1 as var(func: has(<prop1>))
-          |  pred2 as var(func: has(<prop2>))
-          |  pred3 as var(func: has(<edge1>))
-          |  pred4 as var(func: has(<edge2>))
-          |
-          |  result (func: uid(pred1,pred2,pred3,pred4)) {
-          |    count(uid)
           |  }
           |}""".stripMargin)
     }
 
     it("should use empty predicate queries for none predicates") {
-      val query = PartitionQuery("result", None, None)
+      val query = PartitionQuery("result", None)
       assert(query.getPredicateQueries(None) === Map.empty)
     }
 
     it("should use empty predicate queries for empty predicates") {
-      val query = PartitionQuery("result", Some(Set.empty), None)
+      val query = PartitionQuery("result", Some(Set.empty))
       assert(query.getPredicateQueries(None) === Map.empty)
     }
 
     it("should use single predicate query for for single predicate") {
       Seq(prop, edge).foreach { preds =>
-        val query = PartitionQuery("result", Some(preds), None)
+        val query = PartitionQuery("result", Some(preds))
         assert(query.getPredicateQueries(None) === Map("pred1" -> s"""pred1 as var(func: has(<${preds.head.predicateName}>))"""))
       }
     }
 
     it("should use multiple predicate queries for multiple predicates") {
-      val query = PartitionQuery("result", Some(predicates), None)
+      val query = PartitionQuery("result", Some(predicates))
       assert(query.getPredicateQueries(None) === Map(
         "pred1" -> "pred1 as var(func: has(<prop1>))",
         "pred2" -> "pred2 as var(func: has(<prop2>))",
@@ -369,7 +272,7 @@ class TestPartitionQuery extends FunSpec {
     }
 
     it("should chunk predicate queries") {
-      val query = PartitionQuery("result", Some(predicates), None)
+      val query = PartitionQuery("result", Some(predicates))
       assert(query.getPredicateQueries(Some(Chunk(Uid("0x123"), 10))) === Map(
         "pred1" -> "pred1 as var(func: has(<prop1>), first: 10, after: 0x123)",
         "pred2" -> "pred2 as var(func: has(<prop2>), first: 10, after: 0x123)",
@@ -379,17 +282,17 @@ class TestPartitionQuery extends FunSpec {
     }
 
     it("should have empty predicate paths for none predicates set") {
-      val query = PartitionQuery("result", None, None)
+      val query = PartitionQuery("result", None)
       assert(query.predicatePaths === Seq.empty)
     }
 
     it("should have empty predicate paths for empty predicates set") {
-      val query = PartitionQuery("result", Some(Set.empty), None)
+      val query = PartitionQuery("result", Some(Set.empty))
       assert(query.predicatePaths === Seq.empty)
     }
 
     it("should have predicate paths for given predicates set") {
-      val query = PartitionQuery("result", Some(predicates), None)
+      val query = PartitionQuery("result", Some(predicates))
       assert(query.predicatePaths === Seq(
         "<prop1>",
         "<prop2>",

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/model/TestChunkIterator.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/model/TestChunkIterator.scala
@@ -2,11 +2,10 @@ package uk.co.gresearch.spark.dgraph.connector.model
 
 import com.google.gson.{JsonArray, JsonObject, JsonPrimitive}
 import org.scalatest.FunSpec
+import uk.co.gresearch.spark.dgraph.connector.model.TestChunkIterator.getChunk
 import uk.co.gresearch.spark.dgraph.connector.{Chunk, Uid}
 
-import scala.collection.JavaConverters._
-
-class TestChunkIterator extends FunSpec{
+class TestChunkIterator extends FunSpec {
 
   describe("ChunkIterator") {
 
@@ -14,23 +13,16 @@ class TestChunkIterator extends FunSpec{
 
     it("should handle empty result set") {
       val chunks = Map(Chunk(zero, 10) -> new JsonArray())
-      val it = ChunkIterator(zero, 10, chunk => chunks.getOrElse(chunk, fail(s"unexpected chunk: $chunk")))
+      val it = ChunkIterator(zero, None, 10, chunk => chunks.getOrElse(chunk, fail(s"unexpected chunk: $chunk")))
       assert(it.toSeq === Seq.empty)
     }
 
     it("should handle empty chunk") {
-      val uids = 0 until 10 map { id => Uid(id*7) }
-
-      val chunk = new JsonArray()
-      uids.foreach { uid =>
-        val element = new JsonObject()
-        element.add("uid", new JsonPrimitive(uid.toHexString))
-        chunk.add(element)
-      }
-
+      val uids = 0 until 10 map { id => Uid(id * 7) }
+      val chunk = getChunk(uids)
       // last uid of first chunk is 9*7 = 73, 0x3f in hex
       val chunks = Map(Chunk(zero, 10) -> chunk, Chunk(Uid("0x3f"), 10) -> new JsonArray())
-      val it = ChunkIterator(zero, 10, chunk => chunks.getOrElse(chunk, fail(s"unexpected chunk: $chunk")))
+      val it = ChunkIterator(zero, None, 10, chunk => chunks.getOrElse(chunk, fail(s"unexpected chunk: $chunk")))
       assert(it.toSeq === Seq(chunk))
     }
 
@@ -38,28 +30,53 @@ class TestChunkIterator extends FunSpec{
       val uids = 1 to 13 map { id => Uid(id * 7) }
       val uidChunks = uids.grouped(5).toSeq
 
-      val chunks = uidChunks.map { uids =>
-        val chunk = new JsonArray()
-        uids.foreach { uid =>
-          val element = new JsonObject()
-          element.add("uid", new JsonPrimitive(uid.toHexString))
-          chunk.add(element)
-        }
-        chunk
-      }.zip(Seq(zero) ++ uidChunks.map(_.last).dropRight(1)).map {
-        case (chunk, uid) => Chunk(uid, 5) -> chunk
-      }.toMap
+      val chunks =
+        uidChunks
+          .map(getChunk)
+          .zip(Seq(zero) ++ uidChunks.map(_.last).dropRight(1))
+          .map {
+            case (chunk, uid) => Chunk(uid, 5) -> chunk
+          }.toMap
 
-      val it = ChunkIterator(zero, 5, chunk => chunks.getOrElse(chunk, fail(s"unexpected chunk: $chunk")))
+      val it = ChunkIterator(zero, None, 5, chunk => chunks.getOrElse(chunk, fail(s"unexpected chunk: $chunk")))
+      assert(it.toSeq === chunks.values.toStream)
+    }
+
+    it("should limit chunk size of last chunk in uid range") {
+      val chunks = Map(
+        Chunk(Uid(0), 10) -> getChunk(1 to 10 map { id => Uid(id) }),
+        Chunk(Uid(10), 4) -> getChunk(11 to 14 map { id => Uid(id) })
+      )
+
+      val it = ChunkIterator(zero, Some(Uid(15)), 10, chunk => chunks.getOrElse(chunk, fail(s"unexpected chunk: $chunk")))
       assert(it.toSeq === chunks.values.toStream)
     }
 
     it("should fail on invalid size") {
-      assertThrows[IllegalArgumentException] { ChunkIterator(zero, 0, null) }
-      assertThrows[IllegalArgumentException] { ChunkIterator(zero, -1, null) }
-      assertThrows[IllegalArgumentException] { ChunkIterator(zero, Int.MinValue, null) }
+      assertThrows[IllegalArgumentException] {
+        ChunkIterator(zero, None, 0, null)
+      }
+      assertThrows[IllegalArgumentException] {
+        ChunkIterator(zero, None, -1, null)
+      }
+      assertThrows[IllegalArgumentException] {
+        ChunkIterator(zero, None, Int.MinValue, null)
+      }
     }
 
+    // TODO: test with non-none after
   }
 
+}
+
+object TestChunkIterator {
+  def getChunk(uids: Seq[Uid]): JsonArray = {
+    val chunk = new JsonArray()
+    uids.foreach { uid =>
+      val element = new JsonObject()
+      element.add("uid", new JsonPrimitive(uid.toHexString))
+      chunk.add(element)
+    }
+    chunk
+  }
 }

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/model/TestChunkIterator.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/model/TestChunkIterator.scala
@@ -10,9 +10,11 @@ class TestChunkIterator extends FunSpec{
 
   describe("ChunkIterator") {
 
+    val zero = Uid("0x0")
+
     it("should handle empty result set") {
-      val chunks = Map(Chunk(Uid("0x0"), 10) -> new JsonArray())
-      val it = ChunkIterator(10, chunk => chunks.getOrElse(chunk, fail(s"unexpected chunk: $chunk")))
+      val chunks = Map(Chunk(zero, 10) -> new JsonArray())
+      val it = ChunkIterator(zero, 10, chunk => chunks.getOrElse(chunk, fail(s"unexpected chunk: $chunk")))
       assert(it.toSeq === Seq.empty)
     }
 
@@ -20,15 +22,15 @@ class TestChunkIterator extends FunSpec{
       val uids = 0 until 10 map { id => Uid(id*7) }
 
       val chunk = new JsonArray()
-      uids.foreach {uid =>
+      uids.foreach { uid =>
         val element = new JsonObject()
         element.add("uid", new JsonPrimitive(uid.toHexString))
         chunk.add(element)
       }
 
       // last uid of first chunk is 9*7 = 73, 0x3f in hex
-      val chunks = Map(Chunk(Uid("0x0"), 10) -> chunk, Chunk(Uid("0x3f"), 10) -> new JsonArray())
-      val it = ChunkIterator(10, chunk => chunks.getOrElse(chunk, fail(s"unexpected chunk: $chunk")))
+      val chunks = Map(Chunk(zero, 10) -> chunk, Chunk(Uid("0x3f"), 10) -> new JsonArray())
+      val it = ChunkIterator(zero, 10, chunk => chunks.getOrElse(chunk, fail(s"unexpected chunk: $chunk")))
       assert(it.toSeq === Seq(chunk))
     }
 
@@ -44,18 +46,18 @@ class TestChunkIterator extends FunSpec{
           chunk.add(element)
         }
         chunk
-      }.zip(Seq(Uid("0x0")) ++ uidChunks.map(_.last).dropRight(1)).map {
+      }.zip(Seq(zero) ++ uidChunks.map(_.last).dropRight(1)).map {
         case (chunk, uid) => Chunk(uid, 5) -> chunk
       }.toMap
 
-      val it = ChunkIterator(5, chunk => chunks.getOrElse(chunk, fail(s"unexpected chunk: $chunk")))
+      val it = ChunkIterator(zero, 5, chunk => chunks.getOrElse(chunk, fail(s"unexpected chunk: $chunk")))
       assert(it.toSeq === chunks.values.toStream)
     }
 
     it("should fail on invalid size") {
-      assertThrows[IllegalArgumentException] { ChunkIterator(0, null) }
-      assertThrows[IllegalArgumentException] { ChunkIterator(-1, null) }
-      assertThrows[IllegalArgumentException] { ChunkIterator(Int.MinValue, null) }
+      assertThrows[IllegalArgumentException] { ChunkIterator(zero, 0, null) }
+      assertThrows[IllegalArgumentException] { ChunkIterator(zero, -1, null) }
+      assertThrows[IllegalArgumentException] { ChunkIterator(zero, Int.MinValue, null) }
     }
 
   }

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/model/TestGraphTableModel.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/model/TestGraphTableModel.scala
@@ -4,153 +4,178 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.unsafe.types.UTF8String
 import org.scalatest.FunSpec
 import uk.co.gresearch.spark.dgraph.connector
-import uk.co.gresearch.spark.dgraph.connector.encoder.{InternalRowEncoder, StringTripleEncoder}
+import uk.co.gresearch.spark.dgraph.connector.encoder.{InternalRowEncoder, JsonNodeInternalRowEncoder, StringTripleEncoder}
 import uk.co.gresearch.spark.dgraph.connector.executor.{ExecutorProvider, JsonGraphQlExecutor}
-import uk.co.gresearch.spark.dgraph.connector.{GraphQl, Json, Partition, PartitionQuery, Predicate, Target, Uid}
+import uk.co.gresearch.spark.dgraph.connector.{GraphQl, Json, Partition, PartitionQuery, Predicate, Target, Uid, UidRange}
 
 class TestGraphTableModel extends FunSpec {
 
   describe("GraphTableModel") {
 
+    val zeroUid = Uid("0x0")
+
+    def chunkQuery(after: Uid): String =
+      s"""{
+         |  pred1 as var(func: has(<prop>), first: 3, after: ${after.toHexString})
+         |  pred2 as var(func: has(<edge>), first: 3, after: ${after.toHexString})
+         |
+         |  result (func: uid(pred1,pred2), first: 3, after: ${after.toHexString}) {
+         |    uid
+         |    <prop>
+         |    <edge> { uid }
+         |  }
+         |}""".stripMargin
+
+    val emptyChunkResult = """{"result":[]}"""
+
+    val firstFullChunkResult =
+      """{
+        |  "result": [
+        |    {
+        |      "uid": "0x123",
+        |      "prop": "str123",
+        |      "edge": [{"uid": "0x123a"}]
+        |    },
+        |    {
+        |      "uid": "0x124",
+        |      "prop": "str124"
+        |    },
+        |    {
+        |      "uid": "0x125",
+        |      "edge": [{"uid": "0x125a"},{"uid": "0x125b"}]
+        |    }
+        |  ]
+        |}
+        |""".stripMargin
+    val lastUidOfFirstFullChunk = Uid("0x125")
+    val uidBeforeLastUidOfFirstFullChunk = Uid("0x124")
+
+    val secondHalfChunkResult =
+      """{
+        |  "result": [
+        |    {
+        |      "uid": "0x132",
+        |      "prop": "str132",
+        |      "edge": [{"uid": "0x132a"}]
+        |    },
+        |    {
+        |      "uid": "0x135",
+        |      "prop": "str135",
+        |      "edge": [{"uid": "0x135a"}]
+        |    }
+        |  ]
+        |}
+        |""".stripMargin
+    val lastUidOfSecondHalfChunk = Uid("0x135")
+    val uidBeforeLastUidOfSecondHalfChunk = Uid("0x132")
+
+    val expecteds = Seq(
+      InternalRow(Uid("0x123").uid, UTF8String.fromString("prop"), UTF8String.fromString("str123"), UTF8String.fromString("string")),
+      InternalRow(Uid("0x123").uid, UTF8String.fromString("edge"), UTF8String.fromString(Uid("0x123a").toString), UTF8String.fromString("uid")),
+      InternalRow(Uid("0x124").uid, UTF8String.fromString("prop"), UTF8String.fromString("str124"), UTF8String.fromString("string")),
+      InternalRow(Uid("0x125").uid, UTF8String.fromString("edge"), UTF8String.fromString(Uid("0x125a").toString), UTF8String.fromString("uid")),
+      InternalRow(Uid("0x125").uid, UTF8String.fromString("edge"), UTF8String.fromString(Uid("0x125b").toString), UTF8String.fromString("uid")),
+      InternalRow(Uid("0x132").uid, UTF8String.fromString("prop"), UTF8String.fromString("str132"), UTF8String.fromString("string")),
+      InternalRow(Uid("0x132").uid, UTF8String.fromString("edge"), UTF8String.fromString(Uid("0x132a").toString), UTF8String.fromString("uid")),
+      InternalRow(Uid("0x135").uid, UTF8String.fromString("prop"), UTF8String.fromString("str135"), UTF8String.fromString("string")),
+      InternalRow(Uid("0x135").uid, UTF8String.fromString("edge"), UTF8String.fromString(Uid("0x135a").toString), UTF8String.fromString("uid"))
+    )
+
     it("should read empty result") {
-      val results = Map(
-        """{
-          |  pred1 as var(func: has(<prop>), first: 3, after: 0x0)
-          |  pred2 as var(func: has(<edge>), first: 3, after: 0x0)
-          |
-          |  result (func: uid(pred1,pred2), first: 3, after: 0x0) {
-          |    uid
-          |    <prop>
-          |    <edge> { uid }
-          |  }
-          |}""".stripMargin -> """{"result":[]}""")
-      doTest(3, results, Seq.empty)
+      val results = Map(chunkQuery(zeroUid) -> emptyChunkResult)
+      doTest(results, Seq.empty)
     }
 
     it("should read empty chunk") {
       val results = Map(
-        """{
-          |  pred1 as var(func: has(<prop>), first: 3, after: 0x0)
-          |  pred2 as var(func: has(<edge>), first: 3, after: 0x0)
-          |
-          |  result (func: uid(pred1,pred2), first: 3, after: 0x0) {
-          |    uid
-          |    <prop>
-          |    <edge> { uid }
-          |  }
-          |}""".stripMargin
-          ->
-          """{
-            |  "result": [
-            |    {
-            |      "uid": "0x123",
-            |      "prop": "str123",
-            |      "edge": [{"uid": "0x123a"}]
-            |    },
-            |    {
-            |      "uid": "0x124",
-            |      "prop": "str124"
-            |    },
-            |    {
-            |      "uid": "0x125",
-            |      "edge": [{"uid": "0x125a"},{"uid": "0x125b"}]
-            |    }
-            |  ]
-            |}
-            |""".stripMargin,
-        """{
-          |  pred1 as var(func: has(<prop>), first: 3, after: 0x125)
-          |  pred2 as var(func: has(<edge>), first: 3, after: 0x125)
-          |
-          |  result (func: uid(pred1,pred2), first: 3, after: 0x125) {
-          |    uid
-          |    <prop>
-          |    <edge> { uid }
-          |  }
-          |}""".stripMargin -> """{"result":[]}""")
-      val expected = Seq(
-        InternalRow(Uid("0x123").uid, UTF8String.fromString("prop"), UTF8String.fromString("str123"), UTF8String.fromString("string")),
-        InternalRow(Uid("0x123").uid, UTF8String.fromString("edge"), UTF8String.fromString(Uid("0x123a").toString), UTF8String.fromString("uid")),
-        InternalRow(Uid("0x124").uid, UTF8String.fromString("prop"), UTF8String.fromString("str124"), UTF8String.fromString("string")),
-        InternalRow(Uid("0x125").uid, UTF8String.fromString("edge"), UTF8String.fromString(Uid("0x125a").toString), UTF8String.fromString("uid")),
-        InternalRow(Uid("0x125").uid, UTF8String.fromString("edge"), UTF8String.fromString(Uid("0x125b").toString), UTF8String.fromString("uid"))
+        chunkQuery(zeroUid) -> firstFullChunkResult,
+        chunkQuery(lastUidOfFirstFullChunk) -> emptyChunkResult
       )
-      doTest(3, results, expected)
+
+      val expected = expecteds.filter(_.getLong(0) <= lastUidOfFirstFullChunk.uid)
+      doTest(results, expected)
     }
 
     it("should read all chunks") {
       val results = Map(
-        """{
-          |  pred1 as var(func: has(<prop>), first: 3, after: 0x0)
-          |  pred2 as var(func: has(<edge>), first: 3, after: 0x0)
-          |
-          |  result (func: uid(pred1,pred2), first: 3, after: 0x0) {
-          |    uid
-          |    <prop>
-          |    <edge> { uid }
-          |  }
-          |}""".stripMargin
-          ->
-          """{
-            |  "result": [
-            |    {
-            |      "uid": "0x123",
-            |      "prop": "str123",
-            |      "edge": [{"uid": "0x123a"}]
-            |    },
-            |    {
-            |      "uid": "0x124",
-            |      "prop": "str124"
-            |    },
-            |    {
-            |      "uid": "0x125",
-            |      "edge": [{"uid": "0x125a"},{"uid": "0x125b"}]
-            |    }
-            |  ]
-            |}
-            |""".stripMargin,
-        """{
-          |  pred1 as var(func: has(<prop>), first: 3, after: 0x125)
-          |  pred2 as var(func: has(<edge>), first: 3, after: 0x125)
-          |
-          |  result (func: uid(pred1,pred2), first: 3, after: 0x125) {
-          |    uid
-          |    <prop>
-          |    <edge> { uid }
-          |  }
-          |}""".stripMargin
-          ->
-          """{
-            |  "result": [
-            |    {
-            |      "uid": "0x132",
-            |      "prop": "str132",
-            |      "edge": [{"uid": "0x132a"}]
-            |    }
-            |  ]
-            |}
-            |""".stripMargin
+        chunkQuery(zeroUid) -> firstFullChunkResult,
+        chunkQuery(lastUidOfFirstFullChunk) -> secondHalfChunkResult
       )
-      val expected = Seq(
-        InternalRow(Uid("0x123").uid, UTF8String.fromString("prop"), UTF8String.fromString("str123"), UTF8String.fromString("string")),
-        InternalRow(Uid("0x123").uid, UTF8String.fromString("edge"), UTF8String.fromString(Uid("0x123a").toString), UTF8String.fromString("uid")),
-        InternalRow(Uid("0x124").uid, UTF8String.fromString("prop"), UTF8String.fromString("str124"), UTF8String.fromString("string")),
-        InternalRow(Uid("0x125").uid, UTF8String.fromString("edge"), UTF8String.fromString(Uid("0x125a").toString), UTF8String.fromString("uid")),
-        InternalRow(Uid("0x125").uid, UTF8String.fromString("edge"), UTF8String.fromString(Uid("0x125b").toString), UTF8String.fromString("uid")),
-        InternalRow(Uid("0x132").uid, UTF8String.fromString("prop"), UTF8String.fromString("str132"), UTF8String.fromString("string")),
-        InternalRow(Uid("0x132").uid, UTF8String.fromString("edge"), UTF8String.fromString(Uid("0x132a").toString), UTF8String.fromString("uid"))
-      )
-      doTest(3, results, expected)
+
+      val expected = expecteds.filter(_.getLong(0) <= lastUidOfSecondHalfChunk.uid)
+      doTest(results, expected)
     }
 
-    def doTest(size: Int, results: Map[String, String], expected: Seq[InternalRow]): Unit = {
+    it("should read empty result in uid-range") {
+      val firstUid = Uid("0x100")
+      val untilUid = Uid("0x200")
+      val range = UidRange(firstUid, untilUid)
+      val results = Map(
+        chunkQuery(firstUid.before) -> emptyChunkResult
+      )
+
+      doTest(results, Seq.empty, Some(range))
+    }
+
+    it("should read empty chunk in uid-range") {
+      val firstUid = Uid("0x100")
+      val untilUid = Uid("0x200")
+      val range = UidRange(firstUid, untilUid)
+      val results = Map(
+        chunkQuery(firstUid.before) -> firstFullChunkResult,
+        chunkQuery(lastUidOfFirstFullChunk) -> emptyChunkResult
+      )
+
+      val expected = expecteds.filter(_.getLong(0) <= lastUidOfFirstFullChunk.uid)
+      doTest(results, expected, Some(range))
+    }
+
+    it("should read chopped first chunk in uid-range") {
+      val firstUid = Uid("0x100")
+      val untilUid = lastUidOfFirstFullChunk
+      val range = UidRange(firstUid, untilUid)
+      val results = Map(
+        chunkQuery(firstUid.before) -> firstFullChunkResult
+      )
+
+      val expected = expecteds.filter(_.getLong(0) <= uidBeforeLastUidOfFirstFullChunk.uid)
+      doTest(results, expected, Some(range))
+    }
+
+    it("should read chopped second chunk in uid-range") {
+      val firstUid = Uid("0x100")
+      val untilUid = lastUidOfSecondHalfChunk
+      val range = UidRange(firstUid, untilUid)
+      val results = Map(
+        chunkQuery(firstUid.before) -> firstFullChunkResult,
+        chunkQuery(lastUidOfFirstFullChunk) -> secondHalfChunkResult
+      )
+
+      val expected = expecteds.filter(_.getLong(0) <= uidBeforeLastUidOfSecondHalfChunk.uid)
+      doTest(results, expected, Some(range))
+    }
+
+    it("should read all chunks in uid-range") {
+      val firstUid = Uid("0x100")
+      val untilUid = Uid("0x200")
+      val range = UidRange(firstUid, untilUid)
+      val results = Map(
+        chunkQuery(firstUid.before) -> firstFullChunkResult,
+        chunkQuery(lastUidOfFirstFullChunk) -> secondHalfChunkResult
+      )
+
+      val expected = expecteds.filter(_.getLong(0) <= lastUidOfSecondHalfChunk.uid)
+      doTest(results, expected, Some(range))
+    }
+
+    def doTest(results: Map[String, String], expected: Seq[InternalRow], uids: Option[UidRange] = None, size: Int = 3): Unit = {
       val targets = Seq(Target("localhost:8090"))
       val predicates = Seq(Predicate("prop", "string"), Predicate("edge", "uid")).map(p => p.predicateName -> p).toMap
 
       val executor = new JsonGraphQlExecutor {
         override def query(query: GraphQl): Json =
           results.get(query.string).map(Json)
-            .getOrElse(fail(s"unexpected query: ${query.string}"))
+            .getOrElse(fail(s"unexpected query:\n${query.string}\n\nexpected queries:\n${results.keys.mkString("\n")}"))
       }
 
       val executionProvider = new ExecutorProvider {
@@ -161,17 +186,17 @@ class TestGraphTableModel extends FunSpec {
 
       val model = new GraphTableModel {
         override val execution: ExecutorProvider = executionProvider
-        override val encoder: InternalRowEncoder = rowEncoder
-        override val chunkSize: Option[Int] = Some(size)
+        override val encoder: JsonNodeInternalRowEncoder = rowEncoder
+        override val chunkSize: Int = size
 
         override def toGraphQl(query: PartitionQuery, chunk: Option[connector.Chunk]): connector.GraphQl =
           query.forPropertiesAndEdges(chunk)
 
       }
 
-      val partition = Partition(targets, Some(predicates.values.toSet), None)
+      val partition = Partition(targets, Some(predicates.values.toSet), uids)
 
-      val rows = model.readChunks(partition, size).toSeq
+      val rows = model.modelPartition(partition).toSeq
       assert(rows === expected)
     }
 

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestPartitionerProvider.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestPartitionerProvider.scala
@@ -36,10 +36,7 @@ class TestPartitionerProvider extends FunSpec {
     10000,
     UUID.randomUUID()
   )
-  val countEstimator: UidCardinalityEstimator = MaxLeaseIdUidCardinalityEstimator(state.maxLeaseId)
-  val queryEstimator: UidCardinalityEstimator = QueryUidCardinalityEstimator(DgraphExecutor(target))
-
-  assert(UidRangePartitionerEstimatorDefault === UidCountEstimatorOption, "tests assume this default estimator")
+  val maxLeaseEstimator: UidCardinalityEstimator = MaxLeaseIdUidCardinalityEstimator(state.maxLeaseId)
 
   describe("PartitionerProvider") {
 
@@ -47,7 +44,7 @@ class TestPartitionerProvider extends FunSpec {
     val group = GroupPartitioner(schema, state)
     val alpha = AlphaPartitioner(schema, state, AlphaPartitionerPartitionsDefault)
     val pred = PredicatePartitioner(schema, state, PredicatePartitionerPredicatesDefault)
-    val uidRange = UidRangePartitioner(singleton, UidRangePartitionerUidsPerPartDefault, queryEstimator)
+    val uidRange = UidRangePartitioner(singleton, UidRangePartitionerUidsPerPartDefault, maxLeaseEstimator)
 
     Seq(
       ("singleton", singleton),
@@ -77,7 +74,7 @@ class TestPartitionerProvider extends FunSpec {
       val partitioner = provider.getPartitioner(schema, state, options)
 
       val predicatePart = PredicatePartitioner(schema, state, PredicatePartitionerPredicatesDefault)
-      val expected = UidRangePartitioner(predicatePart, UidRangePartitionerUidsPerPartDefault, queryEstimator)
+      val expected = UidRangePartitioner(predicatePart, UidRangePartitionerUidsPerPartDefault, maxLeaseEstimator)
       assert(partitioner === expected)
     }
 
@@ -135,7 +132,7 @@ class TestPartitionerProvider extends FunSpec {
         UidRangePartitionerEstimatorOption -> MaxLeaseIdEstimatorOption,
       ).asJava)
       val partitioner = provider.getPartitioner(schema, state, options)
-      assert(partitioner === uidRange.copy(uidsPerPartition = 2, uidCardinalityEstimator = countEstimator))
+      assert(partitioner === uidRange.copy(uidsPerPartition = 2, uidCardinalityEstimator = maxLeaseEstimator))
     }
 
     it(s"should provide alpha uid-range partitioner with non-default values via option") {
@@ -148,7 +145,7 @@ class TestPartitionerProvider extends FunSpec {
       ).asJava)
       val partitioner = provider.getPartitioner(schema, state, options)
       assert(partitioner === uidRange.copy(partitioner = alpha.copy(partitionsPerAlpha = 2),
-        uidsPerPartition = 2, uidCardinalityEstimator = countEstimator))
+        uidsPerPartition = 2, uidCardinalityEstimator = maxLeaseEstimator))
     }
 
     it(s"should provide predicate partitioner with non-default values via option") {
@@ -161,7 +158,7 @@ class TestPartitionerProvider extends FunSpec {
       ).asJava)
       val partitioner = provider.getPartitioner(schema, state, options)
       assert(partitioner === uidRange.copy(partitioner = pred.copy(predicatesPerPartition = 2),
-        uidsPerPartition = 2, uidCardinalityEstimator = countEstimator))
+        uidsPerPartition = 2, uidCardinalityEstimator = maxLeaseEstimator))
     }
 
   }

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestEdgeSource.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestEdgeSource.scala
@@ -184,7 +184,8 @@ class TestEdgeSource extends FunSpec
           .options(Map(
             PartitionerOption -> UidRangePartitionerOption,
             UidRangePartitionerUidsPerPartOption -> "2",
-            UidRangePartitionerEstimatorOption -> UidCountEstimatorOption,
+            UidRangePartitionerEstimatorOption -> MaxLeaseIdEstimatorOption,
+            MaxLeaseIdEstimatorIdOption -> highestUid.toString
           ))
           .dgraphEdges(target)
           .mapPartitions(part => Iterator(part.map(_.getLong(0)).toSet))

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestNodeSource.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestNodeSource.scala
@@ -186,7 +186,8 @@ class TestNodeSource extends FunSpec
             NodesModeOption -> NodesModeWideOption,
             PartitionerOption -> s"$PredicatePartitionerOption+$UidRangePartitionerOption",
             PredicatePartitionerPredicatesOption -> "1",
-            UidRangePartitionerUidsPerPartOption -> "1"
+            UidRangePartitionerUidsPerPartOption -> "1",
+            MaxLeaseIdEstimatorIdOption -> highestUid.toString
           ))
           .dgraphNodes(cluster.grpc)
       )
@@ -285,7 +286,8 @@ class TestNodeSource extends FunSpec
           .read
           .options(Map(
             PartitionerOption -> UidRangePartitionerOption,
-            UidRangePartitionerUidsPerPartOption -> "7"
+            UidRangePartitionerUidsPerPartOption -> "7",
+            MaxLeaseIdEstimatorIdOption -> highestUid.toString
           ))
           .dgraphNodes(target)
           .mapPartitions(part => Iterator(part.map(_.getLong(0)).toSet))

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestTriplesSource.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestTriplesSource.scala
@@ -34,7 +34,7 @@ class TestTriplesSource extends FunSpec
   describe("TriplesDataSource") {
 
     def doTestLoadTypedTriples(load: () => DataFrame): Unit = {
-      val triples = load().as[TypedTriple].collect().toSet
+      val triples = load().repar.as[TypedTriple].collect().toSet
       TestTriplesSource.doAssertTriples(triples, this)
     }
 
@@ -281,8 +281,11 @@ class TestTriplesSource extends FunSpec
       val partitions =
         spark
           .read
-          .option(PartitionerOption, s"$UidRangePartitionerOption")
-          .option(UidRangePartitionerUidsPerPartOption, "7")
+          .options(Map(
+            PartitionerOption -> s"$UidRangePartitionerOption",
+            UidRangePartitionerUidsPerPartOption -> "7",
+            MaxLeaseIdEstimatorIdOption -> highestUid.toString
+          ))
           .dgraphTriples(target)
           .rdd
           .partitions.map {
@@ -291,8 +294,8 @@ class TestTriplesSource extends FunSpec
         }
 
       val expected = Set(
-        Some(Partition(Seq(Target(cluster.grpc)), None, Some(UidRange(0, 7)))),
-        Some(Partition(Seq(Target(cluster.grpc)), None, Some(UidRange(7, 7)))),
+        Some(Partition(Seq(Target(cluster.grpc)), None, Some(UidRange(Uid(1), Uid(8))))),
+        Some(Partition(Seq(Target(cluster.grpc)), None, Some(UidRange(Uid(8), Uid(15))))),
       )
 
       assert(partitions.toSet === expected)
@@ -303,9 +306,12 @@ class TestTriplesSource extends FunSpec
       val partitions =
         spark
           .read
-          .option(PartitionerOption, s"$PredicatePartitionerOption+$UidRangePartitionerOption")
-          .option(PredicatePartitionerPredicatesOption, "2")
-          .option(UidRangePartitionerUidsPerPartOption, "5")
+          .options(Map(
+            PartitionerOption -> s"$PredicatePartitionerOption+$UidRangePartitionerOption",
+            PredicatePartitionerPredicatesOption -> "2",
+            UidRangePartitionerUidsPerPartOption -> "5",
+            MaxLeaseIdEstimatorIdOption -> highestUid.toString
+          ))
           .dgraphTriples(target)
           .rdd
           .partitions.map {
@@ -313,17 +319,15 @@ class TestTriplesSource extends FunSpec
           case _ => None
         }
 
-      val expected = Set(
-        Some(Partition(Seq(Target(cluster.grpc)), Some(Set(Predicate("release_date", "datetime"), Predicate("starring", "uid"))), None)),
-        Some(Partition(Seq(Target(cluster.grpc)), Some(Set(Predicate("revenue", "float"))), None)),
-        Some(Partition(Seq(Target(cluster.grpc)), Some(Set(Predicate("dgraph.graphql.schema", "string"), Predicate("running_time", "int"))), None)),
-        Some(Partition(Seq(Target(cluster.grpc)), Some(Set(Predicate("dgraph.type", "string"), Predicate("dgraph.graphql.xid", "string"))), Some(UidRange(0, 5)))),
-        Some(Partition(Seq(Target(cluster.grpc)), Some(Set(Predicate("dgraph.type", "string"), Predicate("dgraph.graphql.xid", "string"))), Some(UidRange(5, 5)))),
-        Some(Partition(Seq(Target(cluster.grpc)), Some(Set(Predicate("dgraph.type", "string"), Predicate("dgraph.graphql.xid", "string"))), Some(UidRange(10, 5)))),
-        Some(Partition(Seq(Target(cluster.grpc)), Some(Set(Predicate("director", "uid"), Predicate("name", "string"))), Some(UidRange(0, 5)))),
-        Some(Partition(Seq(Target(cluster.grpc)), Some(Set(Predicate("director", "uid"), Predicate("name", "string"))), Some(UidRange(5, 5))))
+      val ranges = Seq(UidRange(Uid(1), Uid(6)), UidRange(Uid(6), Uid(11)), UidRange(Uid(11), Uid(16)))
 
-      )
+      val expected = Set(
+        Partition(Seq(Target(cluster.grpc)), Some(Set(Predicate("release_date", "datetime"), Predicate("starring", "uid"))), None),
+        Partition(Seq(Target(cluster.grpc)), Some(Set(Predicate("revenue", "float"))), None),
+        Partition(Seq(Target(cluster.grpc)), Some(Set(Predicate("dgraph.graphql.schema", "string"), Predicate("running_time", "int"))), None),
+        Partition(Seq(Target(cluster.grpc)), Some(Set(Predicate("dgraph.type", "string"), Predicate("dgraph.graphql.xid", "string"))), None),
+        Partition(Seq(Target(cluster.grpc)), Some(Set(Predicate("director", "uid"), Predicate("name", "string"))), None)
+      ).flatMap(partition => ranges.map(range => Some(partition.copy(uids = Some(range)))))
 
       assert(partitions.toSet === expected)
     }
@@ -335,7 +339,8 @@ class TestTriplesSource extends FunSpec
           .read
           .options(Map(
             PartitionerOption -> UidRangePartitionerOption,
-            UidRangePartitionerUidsPerPartOption -> "7"
+            UidRangePartitionerUidsPerPartOption -> "7",
+            MaxLeaseIdEstimatorIdOption -> highestUid.toString
           ))
           .dgraphTriples(target)
           .mapPartitions(part => Iterator(part.map(_.getLong(0)).toSet))

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestTriplesSource.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestTriplesSource.scala
@@ -34,7 +34,7 @@ class TestTriplesSource extends FunSpec
   describe("TriplesDataSource") {
 
     def doTestLoadTypedTriples(load: () => DataFrame): Unit = {
-      val triples = load().repar.as[TypedTriple].collect().toSet
+      val triples = load().as[TypedTriple].collect().toSet
       TestTriplesSource.doAssertTriples(triples, this)
     }
 

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/graphframes/TestGraphFrames.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/graphframes/TestGraphFrames.scala
@@ -98,7 +98,6 @@ class TestGraphFrames extends FunSpec
           Row(richard, null, null, "Person", "Richard Marquand", null, null, null, 0.9843173431734319.toFloat),
         )
       )
-      doubleTriples.show(100, false)
       assert(triplets === expected)
     }
 


### PR DESCRIPTION
Uses chunk iteration to partition into uid ranges
Removes offset and count usage in GraphQl
Removes QueryUidCardinalityEstimator that counts result set size

Fixes #32