### PR TITLE
Refactoring public API and dgraph test cluster architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add example how to load Dgraph data in PySpark. Fixed dependency conflicts between connector dependencies and Spark.
 
 ### Changed
+- Refactored connector API, renamed `spark.read.dgraph*` methods to `spark.read.dgraph.*`.
+- Moved `triples`, `edges` and `nodes` sources from package `uk.co.gresearch.spark.dgraph.connector` to `uk.co.gresearch.spark.dgraph`.
 - Moved Dgraph client to 20.03.1 and Dgraph test cluster to 20.07.0.
 
 ## [0.4.0] - 2020-07-24

--- a/README.md
+++ b/README.md
@@ -13,25 +13,33 @@ and partitioning by orthogonal dimensions [predicates](#partitioning-by-predicat
 
 Example Scala code:
 
-    val target = "localhost:9080"
+```scala
+val target = "localhost:9080"
 
-    import uk.co.gresearch.spark.dgraph.graphx._
-    val graph: Graph[VertexProperty, EdgeProperty] = spark.read.dgraph(target)
+import uk.co.gresearch.spark.dgraph.graphx._
+val graph: Graph[VertexProperty, EdgeProperty] = spark.read.dgraph.graphx(target)
+val edges: RDD[Edge[EdgeProperty]] = spark.read.dgraph.edges(target)
+val vertices: RDD[(VertexId, VertexProperty)] = spark.read.dgraph.vertices(target)
 
-    import uk.co.gresearch.spark.dgraph.graphframes._
-    val graph: GraphFrame = spark.read.dgraph(target)
+import uk.co.gresearch.spark.dgraph.graphframes._
+val graph: GraphFrame = spark.read.dgraph.graphframes(target)
+val edges: DataFrame = spark.read.dgraph.edges(target)
+val vertices: DataFrame = spark.read.dgraph.vertices(target)
 
-    import uk.co.gresearch.spark.dgraph.connector._
-    val triples: DataFrame = spark.read.dgraphTriples(target)
-    val edges: DataFrame = spark.read.dgraphEdges(target)
-    val nodes: DataFrame = spark.read.dgraphNodes(target)
+import uk.co.gresearch.spark.dgraph.connector._
+val triples: DataFrame = spark.read.dgraph.triples(target)
+val edges: DataFrame = spark.read.dgraph.edges(target)
+val nodes: DataFrame = spark.read.dgraph.nodes(target)
+```
 
 With PySpark (pyspark 2.4.2 and ≥3.0) you can use the `spark.read.format(…).load(…)` approach
 (see [PySpark Shell and Python script](#pyspark-shell-and-python-script)):
 
-    spark.read.format("uk.co.gresearch.spark.dgraph.connector.triples").load("localhost:9080")
-    spark.read.format("uk.co.gresearch.spark.dgraph.connector.nodes").load("localhost:9080")
-    spark.read.format("uk.co.gresearch.spark.dgraph.connector.edges").load("localhost:9080")
+```python
+spark.read.format("uk.co.gresearch.spark.dgraph.triples").load("localhost:9080")
+spark.read.format("uk.co.gresearch.spark.dgraph.nodes").load("localhost:9080")
+spark.read.format("uk.co.gresearch.spark.dgraph.edges").load("localhost:9080")
+```
 
 ## Limitations
 
@@ -75,11 +83,15 @@ Add this dependency to your `pom.xml` file to use the latest version:
 
 Launch the Python Spark REPL (pyspark 2.4.2 and ≥3.0) with the Spark Dgraph Connector dependency (version ≥0.4.2) as follows:
 
-    pyspark --packages uk.co.gresearch.spark:spark-dgraph-connector_2.12:0.4.2-3.0 --conf spark.driver.userClassPathFirst=true
+```shell script
+pyspark --packages uk.co.gresearch.spark:spark-dgraph-connector_2.12:0.4.2-3.0 --conf spark.driver.userClassPathFirst=true
+```
 
 Run your Python scripts that use PySpark (pyspark 2.4.2 and ≥3.0) and the Spark Dgraph Connector (version ≥0.4.2) via `spark-submit`:
 
-    spark-submit --packages uk.co.gresearch.spark:spark-dgraph-connector_2.12:0.4.2-3.0 --conf spark.driver.userClassPathFirst=true [script.py]
+```shell script
+spark-submit --packages uk.co.gresearch.spark:spark-dgraph-connector_2.12:0.4.2-3.0 --conf spark.driver.userClassPathFirst=true [script.py]
+```
 
 The `--conf spark.driver.userClassPathFirst=true` is required to avoid the following exception:
 
@@ -98,10 +110,12 @@ a `DROP_ALL` for Dgraph ≥20.07.0 only,
 [Step 3](https://dgraph.io/docs/get-started/#step-3-alter-schema) to add a schema. These steps are
 provided in the following scripts:
 
-    ./dgraph-instance.start.sh
-    ./dgraph-instance.drop_all.sh  # for Dgraph ≥20.07.0 only
-    ./dgraph-instance.insert.sh
-    ./dgraph-instance.schema.sh
+```shell script
+./dgraph-instance.start.sh
+./dgraph-instance.drop_all.sh  # for Dgraph ≥20.07.0 only
+./dgraph-instance.insert.sh
+./dgraph-instance.schema.sh
+```
 
 The Dgraph version can optionally be set via `DGRAPH_TEST_CLUSTER_VERSION` environment variable.
 
@@ -115,30 +129,38 @@ You can load the entire Dgraph database into an
 [Apache Spark GraphX](https://spark.apache.org/docs/latest/graphx-programming-guide.html)
 graph. For example:
 
-    import uk.co.gresearch.spark.dgraph.graphx._
+```scala
+import uk.co.gresearch.spark.dgraph.graphx._
 
-    val graph = spark.read.dgraph("localhost:9080")
+val graph = spark.read.dgraph.graphx("localhost:9080")
+```
 
 Example code to perform a [PageRank](https://spark.apache.org/docs/latest/graphx-programming-guide.html#pagerank)
 computation on the graph to test that the connector is working:
 
-    val pageRank = graph.pageRank(0.0001)
-    pageRank.vertices.foreach(println)
+```scala
+val pageRank = graph.pageRank(0.0001)
+pageRank.vertices.foreach(println)
+```
 
 ### GraphFrames
 
 You can load the entire Dgraph database into a
 [GraphFrames](https://graphframes.github.io/graphframes/docs/_site/index.html) graph. For example:
 
-    import uk.co.gresearch.spark.dgraph.graphframes._
+```scala
+import uk.co.gresearch.spark.dgraph.graphframes._
 
-    val graph: GraphFrame = spark.read.dgraph("localhost:9080")
+val graph: GraphFrame = spark.read.dgraph.graphframes("localhost:9080")
+```
 
 Example code to perform a [PageRank](https://graphframes.github.io/graphframes/docs/_site/user-guide.html#pagerank)
 computation on this graph to test that the connector is working:
 
-    val pageRank = graph.pageRank.maxIter(10)
-    pageRank.run().triplets.show(false)
+```scala
+val pageRank = graph.pageRank.maxIter(10)
+pageRank.run().triplets.show(false)
+```
 
 Note: Predicates get renamed when they are loaded from the Dgraph database. Any `.` (dot) in the name
 is replaced by a `_` (underscore). To guarantee uniqueness of names, underscores in the original predicate
@@ -161,9 +183,11 @@ Dgraph data can be loaded into Spark DataFrames in various forms:
 
 You can load the entire Dgraph database as triples into an [Apache Spark DataFrame](https://spark.apache.org/docs/latest/sql-programming-guide.html#datasets-and-dataframes). For example:
 
-    import uk.co.gresearch.spark.dgraph.connector._
+```scala
+import uk.co.gresearch.spark.dgraph.connector._
 
-    val triples = spark.read.dgraphTriples("localhost:9080")
+val triples = spark.read.dgraph.triples("localhost:9080")
+```
 
 The returned `DataFrame` has the following schema:
 
@@ -201,13 +225,15 @@ This model allows you to store the fully-typed triples in a `DataFrame`.
 
 The triples can also be loaded in an un-typed, narrow form:
 
-    import uk.co.gresearch.spark.dgraph.connector._
+```scala
+import uk.co.gresearch.spark.dgraph.connector._
 
-    spark
-      .read
-      .option(TriplesModeOption, TriplesModeStringOption)
-      .dgraphTriples("localhost:9080")
-      .show
+spark
+  .read
+  .option(TriplesModeOption, TriplesModeStringOption)
+  .dgraph.triples("localhost:9080")
+  .show
+```
 
 The resulting `DataFrame` has the following schema:
 
@@ -240,9 +266,11 @@ with the actual type of the object. Here is an example:
 
 You can load all nodes into a `DataFrame` in a fully-typed form. This contains all the nodes' properties but no edges to other nodes:
 
-    import uk.co.gresearch.spark.dgraph.connector._
+```scala
+import uk.co.gresearch.spark.dgraph.connector._
 
-    spark.read.dgraphNodes("localhost:9080")
+spark.read.dgraph.nodes("localhost:9080")
+```
 
 The returned `DataFrame` has the following schema:
 
@@ -276,12 +304,14 @@ The schema of the returned `DataFrame` is very similar to the typed triples sche
 
 Nodes can also be loaded in a wide, fully-typed format:
 
-    import uk.co.gresearch.spark.dgraph.connector._
+```scala
+import uk.co.gresearch.spark.dgraph.connector._
 
-    spark
-      .read
-      .option(NodesModeOption, NodesModeWideOption)
-      .dgraphNodes("localhost:9080")
+spark
+  .read
+  .option(NodesModeOption, NodesModeWideOption)
+  .dgraph.nodes("localhost:9080")
+```
 
 The returned `DataFrame` has the following schema format, which is dependent on the schema of the underlying Dgraph database.
 Node properties are stored in typed columns and are ordered alphabetically (property columns start after the `subject` column):
@@ -316,9 +346,11 @@ Note: The Wide Nodes source enforces the [predicate partitioner](#partitioning-b
 
 Edges can be loaded as follows:
 
-    import uk.co.gresearch.spark.dgraph.connector._
+```scala
+import uk.co.gresearch.spark.dgraph.connector._
 
-    spark.read.dgraphEdges("localhost:9080")
+spark.read.dgraph.edges("localhost:9080")
+```
 
 The returned `DataFrame` has the following simple schema:
 
@@ -377,20 +409,24 @@ The [Wide Nodes source](#wide-nodes) supports projection pushdown on all [predic
 
 The following query uses filter and projection pushdown. First we define a wide node `DataFrame`:
 
-    val df =
-      spark.read
-        .options(Map(
-          NodesModeOption -> NodesModeWideOption,
-          PartitionerOption -> PredicatePartitionerOption
-        ))
-        .dgraphNodes("localhost:9080")
+```scala
+val df =
+  spark.read
+    .options(Map(
+      NodesModeOption -> NodesModeWideOption,
+      PartitionerOption -> PredicatePartitionerOption
+    ))
+    .dgraph.nodes("localhost:9080")
+```
 
 Then we select some columns (projection) and rows (filter):
 
-    df
-      .select($"subject", $"`dgraph.type`", $"revenue")  // projection
-      .where($"revenue".isNotNull)                       // filter
-      .show()
+```scala
+df
+  .select($"subject", $"`dgraph.type`", $"revenue")  // projection
+  .where($"revenue".isNotNull)                       // filter
+  .show()
+```
 
 This selects the columns `subject`, `dgraph.type` and `revenue` for only those rows that actually have a value for `revenue`.
 The underlying query to Dgraph simplifies from (the full graph):
@@ -448,13 +484,15 @@ summed per partition. The values can be seen on the Spark UI for the respective 
 The connector uses [Spark Accumulators](http://spark.apache.org/docs/1.6.2/api/java/org/apache/spark/Accumulator.html)
 to collect these metrics. They can be accessed by the Spark driver via a `SparkListener`:
 
-      val handler = new SparkListener {
-        override def onStageCompleted(stageCompleted: SparkListenerStageCompleted): Unit =
-          stageCompleted.stageInfo.accumulables.values.foreach(println)
-      }
+```scala
+val handler = new SparkListener {
+  override def onStageCompleted(stageCompleted: SparkListenerStageCompleted): Unit =
+    stageCompleted.stageInfo.accumulables.values.foreach(println)
+}
 
-      spark.sparkContext.addSparkListener(handler)
-      spark.read.dgraphTriples("localhost:9080").count()
+spark.sparkContext.addSparkListener(handler)
+spark.read.dgraph.triples("localhost:9080").count()
+```
 
 
 The following metrics are available:
@@ -466,21 +504,6 @@ The following metrics are available:
 |`Dgraph Time`|Time waited for Dgraph to respond in Seconds.|
 |`Dgraph Uids`|Number of Uids read.|
 
-
-## Special Use Cases
-
-### Nodes without types (dgraph.type)
-
-A graph where nodes do not have any type (`dgraph.type`) can only be read with the `PredicatePartitioner` (see below),
-and then only with a single predicate per partition.
-Any other partitioner relies on the [Dgraphs type system](https://dgraph.io/docs/query-language/#type-system)
-and will therefore not "see" those nodes ([issue #4](https://github.com/G-Research/spark-dgraph-connector/issues/4)).
-
-### Nodes with types and predicates that are not part of its types
-
-A graph where nodes have predicates that are not part of the nodes' types can only be read with the `PredicatePartitioner` (see below).
-Any other partitioner relies on the [Dgraphs type system](https://dgraph.io/docs/query-language/#type-system)
-and will therefore not "see" those predicates ([issue #5](https://github.com/G-Research/spark-dgraph-connector/issues/5)).
 
 ## Partitioning
 
@@ -556,11 +579,13 @@ However, this would be would slow, but it proves the connector can handle any si
 
 The GRPC library used by the dgraph client requires Guava ≥20.0, where ≥24.1.1-jre is recommended, hence the:
 
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>[24.1.1-jre,)</version>
-    </dependency>
+```xml
+<dependency>
+  <groupId>com.google.guava</groupId>
+  <artifactId>guava</artifactId>
+  <version>[24.1.1-jre,)</version>
+</dependency>
+```
 
 …in the `pom.xml`file. Otherwise, we would see this error:
 
@@ -578,11 +603,13 @@ The GRPC library used by the dgraph client requires Guava ≥20.0, where ≥24.1
 
 Furthermore, we need to set `protobuf-java` ≥3.4.0 in the `pom.xml` file:
 
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-      <version>[3.4.0,]</version>
-    </dependency>
+```xml
+<dependency>
+  <groupId>com.google.protobuf</groupId>
+  <artifactId>protobuf-java</artifactId>
+  <version>[3.4.0,]</version>
+</dependency>
+```
 
 …to get rid of these errors:
 

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/DgraphReader.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/DgraphReader.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 G-Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.co.gresearch.spark.dgraph.connector
+
+import org.apache.spark.sql.{DataFrame, DataFrameReader}
+
+case class DgraphReader(reader: DataFrameReader) {
+  /**
+   * Loads all triples of a Dgraph database into a DataFrame. Requires at least one target.
+   * Use triples(targets.head, targets.tail: _*) if you want to provide a Seq[String].
+   *
+   * @param target  a target
+   * @param targets more targets
+   * @return triples DataFrame
+   */
+  def triples(target: String, targets: String*): DataFrame =
+    reader
+      .format(TriplesSource)
+      .load(Seq(target) ++ targets: _*)
+
+  /**
+   * Loads all edges of a Dgraph database into a DataFrame. Requires at least one target.
+   * Use edges(targets.head, targets.tail: _*) if want to provide a Seq[String].
+   *
+   * @param target  a target
+   * @param targets more targets
+   * @return edges DataFrame
+   */
+  def edges(target: String, targets: String*): DataFrame =
+    reader
+      .format(EdgesSource)
+      .load(Seq(target) ++ targets: _*)
+
+  /**
+   * Loads all nodes of a Dgraph database into a DataFrame. Requires at least one target.
+   * Use nodes(targets.head, targets.tail: _*) if you want to provide a Seq[String].
+   *
+   * @param target  a target
+   * @param targets more targets
+   * @return nodes DataFrame
+   */
+  def nodes(target: String, targets: String*): DataFrame =
+    reader
+      .format(NodesSource)
+      .load(Seq(target) ++ targets: _*)
+}

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/package.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/package.scala
@@ -17,15 +17,13 @@
 package uk.co.gresearch.spark.dgraph
 
 import java.sql.Timestamp
-import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
 
 import io.dgraph.DgraphGrpc.DgraphStub
 import io.dgraph.DgraphProto.TxnContext
 import io.dgraph.{DgraphClient, DgraphGrpc}
 import io.grpc.ManagedChannel
 import io.grpc.netty.NettyChannelBuilder
-import org.apache.spark.sql.{DataFrame, DataFrameReader, Encoder, Encoders}
+import org.apache.spark.sql.DataFrameReader
 
 package object connector {
 
@@ -204,50 +202,10 @@ package object connector {
   case class Transaction(context: TxnContext)
 
   implicit class DgraphDataFrameReader(reader: DataFrameReader) {
-
-    val tripleEncoder: Encoder[TypedTriple] = Encoders.product[TypedTriple]
-    val edgeEncoder: Encoder[Edge] = Encoders.product[Edge]
-    val nodeEncoder: Encoder[TypedNode] = Encoders.product[TypedNode]
-
     /**
-     * Loads all triples of a Dgraph database into a DataFrame. Requires at least one target.
-     * Use dgraphTriples(targets.head, targets.tail: _*) if need to provide a Seq[String].
-     *
-     * @param target  a target
-     * @param targets more targets
-     * @return triples DataFrame
+     * Helper to load data of a Dgraph database into a DataFrame.
      */
-    def dgraphTriples(target: String, targets: String*): DataFrame =
-      reader
-        .format(TriplesSource)
-        .load(Seq(target) ++ targets: _*)
-
-    /**
-     * Loads all edges of a Dgraph database into a DataFrame. Requires at least one target.
-     * Use dgraphEdges(targets.head, targets.tail: _*) if need to provide a Seq[String].
-     *
-     * @param target  a target
-     * @param targets more targets
-     * @return edges DataFrame
-     */
-    def dgraphEdges(target: String, targets: String*): DataFrame =
-      reader
-        .format(EdgesSource)
-        .load(Seq(target) ++ targets: _*)
-
-    /**
-     * Loads all ndoes of a Dgraph database into a DataFrame. Requires at least one target.
-     * Use dgraphNodes(targets.head, targets.tail: _*) if need to provide a Seq[String].
-     *
-     * @param target  a target
-     * @param targets more targets
-     * @return nodes DataFrame
-     */
-    def dgraphNodes(target: String, targets: String*): DataFrame =
-      reader
-        .format(NodesSource)
-        .load(Seq(target) ++ targets: _*)
-
+    def dgraph: DgraphReader = DgraphReader(reader)
   }
 
   implicit class AnyValue(value: Any) {

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/edges/DefaultSource.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/edges/DefaultSource.scala
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-package uk.co.gresearch.spark.dgraph.connector.triples
+package uk.co.gresearch.spark.dgraph.edges
 
-import uk.co.gresearch.spark.dgraph.connector.sources.TripleSource
+import uk.co.gresearch.spark.dgraph.connector.sources.EdgeSource
 
-class DefaultSource() extends TripleSource
+class DefaultSource() extends EdgeSource

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/graphframes/GraphFramesReader.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/graphframes/GraphFramesReader.scala
@@ -14,8 +14,19 @@
  * limitations under the License.
  */
 
-package uk.co.gresearch.spark.dgraph.connector.edges
+package uk.co.gresearch.spark.dgraph.graphframes
 
-import uk.co.gresearch.spark.dgraph.connector.sources.EdgeSource
+import org.apache.spark.sql.{DataFrame, DataFrameReader}
+import org.graphframes.GraphFrame
+import uk.co.gresearch.spark.dgraph
 
-class DefaultSource() extends EdgeSource
+case class GraphFramesReader(reader: DataFrameReader) {
+  def graphframes(targets: String*): GraphFrame =
+    dgraph.graphframes.loadGraph(reader, targets: _*)
+
+  def vertices(targets: String*): DataFrame =
+    dgraph.graphframes.loadVertices(reader, targets: _*)
+
+  def edges(targets: String*): DataFrame =
+    dgraph.graphframes.loadEdges(reader, targets: _*)
+}

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/graphframes/package.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/graphframes/package.scala
@@ -34,8 +34,10 @@ package object graphframes {
 
   def loadVertices(reader: DataFrameReader, targets: String*): DataFrame = {
     val vertices =
-      DgraphDataFrameReader(reader.option(NodesModeOption, NodesModeWideOption).option(PredicatePartitionerPredicatesOption, "1"))
-        .dgraphNodes(targets.head, targets.tail: _*)
+      DgraphDataFrameReader(
+        reader.option(NodesModeOption, NodesModeWideOption)
+      )
+        .dgraph.nodes(targets.head, targets.tail: _*)
         .withColumnRenamed("subject", "id")
     val renamedColumns =
       vertices.columns.map(f =>
@@ -49,7 +51,7 @@ package object graphframes {
 
   def loadEdges(reader: DataFrameReader, targets: String*): DataFrame =
     DgraphDataFrameReader(reader)
-      .dgraphEdges(targets.head, targets.tail: _*)
+      .dgraph.edges(targets.head, targets.tail: _*)
       .select(
         col("subject").as("src"),
         col("objectUid").as("dst"),
@@ -57,16 +59,7 @@ package object graphframes {
       )
 
   implicit class GraphFrameDataFrameReader(reader: DataFrameReader) {
-
-    def dgraph(targets: String*): GraphFrame =
-      graphframes.loadGraph(reader, targets: _*)
-
-    def dgraphVertices(targets: String*): DataFrame =
-      graphframes.loadVertices(reader, targets: _*)
-
-    def dgraphEdges(targets: String*): DataFrame =
-      graphframes.loadEdges(reader, targets: _*)
-
+    def dgraph: GraphFramesReader = GraphFramesReader(reader)
   }
 
 }

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/graphx/GraphxReader.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/graphx/GraphxReader.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 G-Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.co.gresearch.spark.dgraph.graphx
+
+import org.apache.spark.graphx.{Graph, VertexId, Edge => GraphxEdge}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.DataFrameReader
+import uk.co.gresearch.spark.dgraph
+import uk.co.gresearch.spark.dgraph.connector.Target
+
+case class GraphxReader(reader: DataFrameReader) {
+  def graphx(targets: String*): Graph[VertexProperty, EdgeProperty] =
+    dgraph.graphx.loadGraph(reader, targets.map(Target): _*)
+
+  def vertices(targets: String*): RDD[(VertexId, VertexProperty)] =
+    dgraph.graphx.loadVertices(reader, targets.map(Target): _*)
+
+  def edges(targets: String*): RDD[GraphxEdge[EdgeProperty]] =
+    dgraph.graphx.loadEdges(reader, targets.map(Target): _*)
+}

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/graphx/package.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/graphx/package.scala
@@ -87,16 +87,7 @@ package object graphx extends TargetsConfigParser {
   }
 
   implicit class GraphxDataFrameReader(reader: DataFrameReader) {
-
-    def dgraph(targets: String*): Graph[VertexProperty, EdgeProperty] =
-      graphx.loadGraph(reader, targets.map(Target): _*)
-
-    def dgraphVertices(targets: String*): RDD[(VertexId, VertexProperty)] =
-      graphx.loadVertices(reader, targets.map(Target): _*)
-
-    def dgraphEdges(targets: String*): RDD[GraphxEdge[EdgeProperty]] =
-      graphx.loadEdges(reader, targets.map(Target): _*)
-
+    def dgraph: GraphxReader = GraphxReader(reader)
   }
 
 }

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/nodes/DefaultSource.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/nodes/DefaultSource.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.co.gresearch.spark.dgraph.connector.nodes
+package uk.co.gresearch.spark.dgraph.nodes
 
 import uk.co.gresearch.spark.dgraph.connector.sources.NodeSource
 

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/triples/DefaultSource.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/triples/DefaultSource.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 G-Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.co.gresearch.spark.dgraph.triples
+
+import uk.co.gresearch.spark.dgraph.connector.sources.TripleSource
+
+class DefaultSource() extends TripleSource

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestClusterStateProvider.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestClusterStateProvider.scala
@@ -25,10 +25,10 @@ class TestClusterStateProvider extends FunSpec with DgraphTestCluster {
 
     it("should retrieve cluster state") {
       val provider = new ClusterStateProvider {}
-      val state = provider.getClusterState(Target(cluster.grpc))
+      val state = provider.getClusterState(Target(dgraph.target))
       assert(state.isDefined === true)
       assert(state.get === ClusterState(
-        Map("1" -> Set(Target(cluster.grpc))),
+        Map("1" -> Set(Target(dgraph.target))),
         Map("1" -> Set("name", "dgraph.graphql.schema", "starring", "dgraph.graphql.xid", "running_time", "release_date", "director", "revenue", "dgraph.type")),
         10000,
         state.get.cid
@@ -37,9 +37,9 @@ class TestClusterStateProvider extends FunSpec with DgraphTestCluster {
 
     it("should retrieve cluster states") {
       val provider = new ClusterStateProvider {}
-      val state = provider.getClusterState(Seq(Target(cluster.grpc), Target(cluster.grpcLocalIp)))
+      val state = provider.getClusterState(Seq(Target(dgraph.target), Target(dgraph.targetLocalIp)))
       assert(state === ClusterState(
-        Map("1" -> Set(Target(cluster.grpc))),
+        Map("1" -> Set(Target(dgraph.target))),
         Map("1" -> Set("name", "dgraph.graphql.schema", "starring", "dgraph.graphql.xid", "running_time", "release_date", "director", "revenue", "dgraph.type")),
         10000,
         state.cid

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestConnector.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestConnector.scala
@@ -29,7 +29,7 @@ class TestConnector extends FunSpec {
     ).foreach {
       case (pkg, source) =>
         it(s"should provide $source source package name") {
-          assert(pkg === s"uk.co.gresearch.spark.dgraph.connector.$source")
+          assert(pkg === s"uk.co.gresearch.spark.dgraph.$source")
         }
     }
 

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestPartition.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestPartition.scala
@@ -32,7 +32,7 @@ class TestPartition extends FunSpec with SchemaProvider with DgraphTestCluster {
       // test that a partition works with N predicates
       // the query grows linearly with N, so does the processing time
       it(s"should read $predicates predicates") {
-        val targets = Seq(Target(cluster.grpc))
+        val targets = Seq(Target(dgraph.target))
         val existingPredicates = getSchema(targets).predicates.slice(0, predicates)
         val syntheticPredicates =
           (1 to (predicates - existingPredicates.size)).map(pred =>

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestNodeSource.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestNodeSource.scala
@@ -18,15 +18,18 @@ package uk.co.gresearch.spark.dgraph.connector.sources
 
 import java.sql.Timestamp
 
+import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.execution.datasources.v2.DataSourceRDDPartition
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.{Column, DataFrame, Dataset, Row}
+import org.apache.spark.sql.{Column, DataFrame, Dataset, Encoders, Row, SparkSession}
 import org.scalatest.FunSpec
 import uk.co.gresearch.spark.SparkTestSession
-import uk.co.gresearch.spark.dgraph.DgraphTestCluster
+import uk.co.gresearch.spark.dgraph.{DgraphTestCluster, DgraphCluster}
 import uk.co.gresearch.spark.dgraph.connector._
+
+import scala.reflect.runtime.universe._
 
 class TestNodeSource extends FunSpec
   with SparkTestSession with DgraphTestCluster
@@ -37,73 +40,15 @@ class TestNodeSource extends FunSpec
 
   describe("NodeDataSource") {
 
-    lazy val expectedTypedNodes = Set(
-      TypedNode(graphQlSchema, "dgraph.type", Some("dgraph.graphql"), None, None, None, None, None, None, "string"),
-      TypedNode(graphQlSchema, "dgraph.graphql.xid", Some("dgraph.graphql.schema"), None, None, None, None, None, None, "string"),
-      TypedNode(graphQlSchema, "dgraph.graphql.schema", Some(""), None, None, None, None, None, None, "string"),
-      TypedNode(st1, "dgraph.type", Some("Film"), None, None, None, None, None, None, "string"),
-      TypedNode(st1, "name", Some("Star Trek: The Motion Picture"), None, None, None, None, None, None, "string"),
-      TypedNode(st1, "release_date", None, None, None, Some(Timestamp.valueOf("1979-12-07 00:00:00.0")), None, None, None, "timestamp"),
-      TypedNode(st1, "revenue", None, None, Some(1.39E8), None, None, None, None, "double"),
-      TypedNode(st1, "running_time", None, Some(132), None, None, None, None, None, "long"),
-      TypedNode(leia, "dgraph.type", Some("Person"), None, None, None, None, None, None, "string"),
-      TypedNode(leia, "name", Some("Princess Leia"), None, None, None, None, None, None, "string"),
-      TypedNode(lucas, "dgraph.type", Some("Person"), None, None, None, None, None, None, "string"),
-      TypedNode(lucas, "name", Some("George Lucas"), None, None, None, None, None, None, "string"),
-      TypedNode(irvin, "dgraph.type", Some("Person"), None, None, None, None, None, None, "string"),
-      TypedNode(irvin, "name", Some("Irvin Kernshner"), None, None, None, None, None, None, "string"),
-      TypedNode(sw1, "dgraph.type", Some("Film"), None, None, None, None, None, None, "string"),
-      TypedNode(sw1, "name", Some("Star Wars: Episode IV - A New Hope"), None, None, None, None, None, None, "string"),
-      TypedNode(sw1, "release_date", None, None, None, Some(Timestamp.valueOf("1977-05-25 00:00:00.0")), None, None, None, "timestamp"),
-      TypedNode(sw1, "revenue", None, None, Some(7.75E8), None, None, None, None, "double"),
-      TypedNode(sw1, "running_time", None, Some(121), None, None, None, None, None, "long"),
-      TypedNode(sw2, "dgraph.type", Some("Film"), None, None, None, None, None, None, "string"),
-      TypedNode(sw2, "name", Some("Star Wars: Episode V - The Empire Strikes Back"), None, None, None, None, None, None, "string"),
-      TypedNode(sw2, "release_date", None, None, None, Some(Timestamp.valueOf("1980-05-21 00:00:00.0")), None, None, None, "timestamp"),
-      TypedNode(sw2, "revenue", None, None, Some(5.34E8), None, None, None, None, "double"),
-      TypedNode(sw2, "running_time", None, Some(124), None, None, None, None, None, "long"),
-      TypedNode(luke, "dgraph.type", Some("Person"), None, None, None, None, None, None, "string"),
-      TypedNode(luke, "name", Some("Luke Skywalker"), None, None, None, None, None, None, "string"),
-      TypedNode(han, "dgraph.type", Some("Person"), None, None, None, None, None, None, "string"),
-      TypedNode(han, "name", Some("Han Solo"), None, None, None, None, None, None, "string"),
-      TypedNode(richard, "dgraph.type", Some("Person"), None, None, None, None, None, None, "string"),
-      TypedNode(richard, "name", Some("Richard Marquand"), None, None, None, None, None, None, "string"),
-      TypedNode(sw3, "dgraph.type", Some("Film"), None, None, None, None, None, None, "string"),
-      TypedNode(sw3, "name", Some("Star Wars: Episode VI - Return of the Jedi"), None, None, None, None, None, None, "string"),
-      TypedNode(sw3, "release_date", None, None, None, Some(Timestamp.valueOf("1983-05-25 00:00:00.0")), None, None, None, "timestamp"),
-      TypedNode(sw3, "revenue", None, None, Some(5.72E8), None, None, None, None, "double"),
-      TypedNode(sw3, "running_time", None, Some(131), None, None, None, None, None, "long"),
-    )
+    lazy val expecteds = NodesSourceExpecteds(dgraph)
+    lazy val expectedTypedNodes = expecteds.getExpectedTypedNodes
+    lazy val expectedWideNodes = expecteds.getExpectedWideNodes
+    lazy val expectedWideSchema: StructType = expecteds.getExpectedWideNodeSchema
 
     def doTestLoadTypedNodes(load: () => DataFrame): Unit = {
       val nodes = load().as[TypedNode].collect().toSet
       assert(nodes === expectedTypedNodes)
     }
-
-    lazy val expectedWideNodes = Set(
-      Row(graphQlSchema, "", "dgraph.graphql.schema", "dgraph.graphql", null, null, null, null),
-      Row(st1, null, null, "Film", "Star Trek: The Motion Picture", Timestamp.valueOf("1979-12-07 00:00:00.0"), 1.39E8, 132),
-      Row(leia, null, null, "Person", "Princess Leia", null, null, null),
-      Row(lucas, null, null, "Person", "George Lucas", null, null, null),
-      Row(irvin, null, null, "Person", "Irvin Kernshner", null, null, null),
-      Row(sw1, null, null, "Film", "Star Wars: Episode IV - A New Hope", Timestamp.valueOf("1977-05-25 00:00:00.0"), 7.75E8, 121),
-      Row(sw2, null, null, "Film", "Star Wars: Episode V - The Empire Strikes Back", Timestamp.valueOf("1980-05-21 00:00:00.0"), 5.34E8, 124),
-      Row(luke, null, null, "Person", "Luke Skywalker", null, null, null),
-      Row(han, null, null, "Person", "Han Solo", null, null, null),
-      Row(richard, null, null, "Person", "Richard Marquand", null, null, null),
-      Row(sw3, null, null, "Film", "Star Wars: Episode VI - Return of the Jedi", Timestamp.valueOf("1983-05-25 00:00:00.0"), 5.72E8, 131)
-    )
-
-    val expectedWideSchema: StructType = StructType(Seq(
-      StructField("subject", LongType, nullable = false),
-      StructField("dgraph.graphql.schema", StringType, nullable = true),
-      StructField("dgraph.graphql.xid", StringType, nullable = true),
-        StructField("dgraph.type", StringType, nullable = true),
-        StructField("name", StringType, nullable = true),
-        StructField("release_date", TimestampType, nullable = true),
-        StructField("revenue", DoubleType, nullable = true),
-        StructField("running_time", LongType, nullable = true)
-    ))
 
     def doTestLoadWideNodes(load: () => DataFrame): Unit = {
       val df = load()
@@ -117,7 +62,7 @@ class TestNodeSource extends FunSpec
         spark
           .read
           .format(NodesSource)
-          .load(cluster.grpc)
+          .load(dgraph.target)
       )
     }
 
@@ -126,7 +71,7 @@ class TestNodeSource extends FunSpec
         spark
           .read
           .format(NodesSource)
-          .load(cluster.grpc, cluster.grpcLocalIp)
+          .load(dgraph.target, dgraph.targetLocalIp)
       )
     }
 
@@ -135,7 +80,7 @@ class TestNodeSource extends FunSpec
         spark
           .read
           .format(NodesSource)
-          .option(TargetOption, cluster.grpc)
+          .option(TargetOption, dgraph.target)
           .load()
       )
     }
@@ -145,7 +90,7 @@ class TestNodeSource extends FunSpec
         spark
           .read
           .format(NodesSource)
-          .option(TargetsOption, s"""["${cluster.grpc}","${cluster.grpcLocalIp}"]""")
+          .option(TargetsOption, s"""["${dgraph.target}","${dgraph.targetLocalIp}"]""")
           .load()
       )
     }
@@ -154,7 +99,7 @@ class TestNodeSource extends FunSpec
       doTestLoadTypedNodes(() =>
         spark
           .read
-          .dgraphNodes(cluster.grpc)
+          .dgraph.nodes(dgraph.target)
       )
     }
 
@@ -162,7 +107,7 @@ class TestNodeSource extends FunSpec
       doTestLoadTypedNodes(() =>
         spark
           .read
-          .dgraphNodes(cluster.grpc, cluster.grpcLocalIp)
+          .dgraph.nodes(dgraph.target)
       )
     }
 
@@ -171,7 +116,7 @@ class TestNodeSource extends FunSpec
         spark
           .read
           .option(NodesModeOption, NodesModeTypedOption)
-          .dgraphNodes(cluster.grpc)
+          .dgraph.nodes(dgraph.target)
       )
     }
 
@@ -180,7 +125,7 @@ class TestNodeSource extends FunSpec
         spark
           .read
           .option(NodesModeOption, NodesModeWideOption)
-          .dgraphNodes(cluster.grpc)
+          .dgraph.nodes(dgraph.target)
       )
     }
 
@@ -193,7 +138,7 @@ class TestNodeSource extends FunSpec
             PartitionerOption -> PredicatePartitionerOption,
             PredicatePartitionerPredicatesOption -> "1"
           ))
-          .dgraphNodes(cluster.grpc)
+          .dgraph.nodes(dgraph.target)
       )
     }
 
@@ -206,9 +151,9 @@ class TestNodeSource extends FunSpec
             PartitionerOption -> s"$PredicatePartitionerOption+$UidRangePartitionerOption",
             PredicatePartitionerPredicatesOption -> "1",
             UidRangePartitionerUidsPerPartOption -> "1",
-            MaxLeaseIdEstimatorIdOption -> highestUid.toString
+            MaxLeaseIdEstimatorIdOption -> dgraph.highestUid.toString
           ))
-          .dgraphNodes(cluster.grpc)
+          .dgraph.nodes(dgraph.target)
       )
     }
 
@@ -223,7 +168,7 @@ class TestNodeSource extends FunSpec
             PredicatePartitionerPredicatesOption -> "2",
             ChunkSizeOption -> "3"
           ))
-          .dgraphNodes(cluster.grpc)
+          .dgraph.nodes(dgraph.target)
       )
     }
 
@@ -232,7 +177,7 @@ class TestNodeSource extends FunSpec
         spark
           .read
           .format(NodesSource)
-          .load(cluster.grpc)
+          .load(dgraph.target)
           .as[TypedNode]
           .collectAsList()
       assert(rows.size() === 35)
@@ -258,13 +203,13 @@ class TestNodeSource extends FunSpec
     }
 
     it("should load as a single partition") {
-      val target = cluster.grpc
+      val target = dgraph.target
       val targets = Seq(Target(target))
       val partitions =
         spark
           .read
           .option(PartitionerOption, SingletonPartitionerOption)
-          .dgraphNodes(target)
+          .dgraph.nodes(target)
           .rdd
           .partitions.map {
           case p: DataSourceRDDPartition => Some(p.inputPartition)
@@ -283,13 +228,13 @@ class TestNodeSource extends FunSpec
     }
 
     it("should load as a predicate partitions") {
-      val target = cluster.grpc
+      val target = dgraph.target
       val partitions =
         spark
           .read
           .option(PartitionerOption, PredicatePartitionerOption)
           .option(PredicatePartitionerPredicatesOption, "2")
-          .dgraphNodes(target)
+          .dgraph.nodes(target)
           .rdd
           .partitions.map {
           case p: DataSourceRDDPartition => Some(p.inputPartition)
@@ -297,33 +242,33 @@ class TestNodeSource extends FunSpec
         }
 
       val expected = Set(
-        Some(Partition(Seq(Target(cluster.grpc))).has(Set("dgraph.type"), Set.empty).getAll),
-        Some(Partition(Seq(Target(cluster.grpc))).has(Set("revenue"), Set.empty).getAll),
-        Some(Partition(Seq(Target(cluster.grpc))).has(Set("dgraph.graphql.schema", "dgraph.graphql.xid"), Set.empty).getAll),
-        Some(Partition(Seq(Target(cluster.grpc))).has(Set("running_time"), Set.empty).getAll),
-        Some(Partition(Seq(Target(cluster.grpc))).has(Set("release_date", "name"), Set.empty).getAll)
+        Some(Partition(Seq(Target(dgraph.target))).has(Set("dgraph.type"), Set.empty).getAll),
+        Some(Partition(Seq(Target(dgraph.target))).has(Set("revenue"), Set.empty).getAll),
+        Some(Partition(Seq(Target(dgraph.target))).has(Set("dgraph.graphql.schema", "dgraph.graphql.xid"), Set.empty).getAll),
+        Some(Partition(Seq(Target(dgraph.target))).has(Set("running_time"), Set.empty).getAll),
+        Some(Partition(Seq(Target(dgraph.target))).has(Set("release_date", "name"), Set.empty).getAll)
       )
 
       assert(partitions.toSet === expected)
     }
 
     it("should partition data") {
-      val target = cluster.grpc
+      val target = dgraph.target
       val partitions =
         spark
           .read
           .options(Map(
             PartitionerOption -> UidRangePartitionerOption,
             UidRangePartitionerUidsPerPartOption -> "7",
-            MaxLeaseIdEstimatorIdOption -> highestUid.toString
+            MaxLeaseIdEstimatorIdOption -> dgraph.highestUid.toString
           ))
-          .dgraphNodes(target)
+          .dgraph.nodes(target)
           .mapPartitions(part => Iterator(part.map(_.getLong(0)).toSet))
           .collect()
 
       // we retrieve partitions in chunks of 7 uids, if there are uids allocated but unused then we get partitions with less than 7 uids
-      val allUidInts = allUids.map(_.toInt).toSet
-      val expected = (1 to highestUid.toInt).grouped(7).map(_.toSet intersect allUidInts).toSeq
+      val allUidInts = dgraph.allUids.map(_.toInt).toSet
+      val expected = (1 to dgraph.highestUid.toInt).grouped(7).map(_.toSet intersect allUidInts).toSeq
       assert(partitions === expected)
     }
 
@@ -335,7 +280,7 @@ class TestNodeSource extends FunSpec
           PartitionerOption -> PredicatePartitionerOption,
           PredicatePartitionerPredicatesOption -> "2"
         ))
-        .dgraphNodes(cluster.grpc)
+        .dgraph.nodes(dgraph.target)
         .as[TypedNode]
 
     lazy val wideNodes =
@@ -345,7 +290,7 @@ class TestNodeSource extends FunSpec
           NodesModeOption -> NodesModeWideOption,
           PartitionerOption -> PredicatePartitionerOption
         ))
-        .dgraphNodes(cluster.grpc)
+        .dgraph.nodes(dgraph.target)
 
 
     def doTestFilterPushDown[T](df: Dataset[T], condition: Column, expectedFilters: Set[Filter], expectedUnpushed: Seq[Expression] = Seq.empty, expectedDs: Set[T]): Unit = {
@@ -363,27 +308,27 @@ class TestNodeSource extends FunSpec
 
     it("should push subject filters") {
       doTestsFilterPushDown(
-        $"subject" === leia,
-        Set(SubjectIsIn(Uid(leia))),
+        $"subject" === dgraph.leia,
+        Set(SubjectIsIn(Uid(dgraph.leia))),
         Seq.empty,
-        (n: TypedNode) => n.subject == leia,
-        (r: Row) => r.getLong(0) == leia
+        (n: TypedNode) => n.subject == dgraph.leia,
+        (r: Row) => r.getLong(0) == dgraph.leia
       )
 
       doTestsFilterPushDown(
-        $"subject".isin(leia),
-        Set(SubjectIsIn(Uid(leia))),
+        $"subject".isin(dgraph.leia),
+        Set(SubjectIsIn(Uid(dgraph.leia))),
         Seq.empty,
-        (n: TypedNode) => n.subject == leia,
-        (r: Row) => r.getLong(0) == leia
+        (n: TypedNode) => n.subject == dgraph.leia,
+        (r: Row) => r.getLong(0) == dgraph.leia
       )
 
       doTestsFilterPushDown(
-        $"subject".isin(leia, luke),
-        Set(SubjectIsIn(Uid(leia), Uid(luke))),
+        $"subject".isin(dgraph.leia, dgraph.luke),
+        Set(SubjectIsIn(Uid(dgraph.leia), Uid(dgraph.luke))),
         Seq.empty,
-        (n: TypedNode) => Set(leia, luke).contains(n.subject),
-        (r: Row) => Set(leia, luke).contains(r.getLong(0))
+        (n: TypedNode) => Set(dgraph.leia, dgraph.luke).contains(n.subject),
+        (r: Row) => Set(dgraph.leia, dgraph.luke).contains(r.getLong(0))
       )
     }
 
@@ -510,10 +455,10 @@ class TestNodeSource extends FunSpec
         doTestFilterPushDown(wideNodes,
           $"name" === "Star Wars: Episode IV - A New Hope" && $"running_time" === 121,
           Set(SinglePredicateValueIsIn("name", Set("Star Wars: Episode IV - A New Hope")), SinglePredicateValueIsIn("running_time", Set(121))),
-          expectedDs = expectedWideNodes.filter(r => Option(r.getString(columns.indexOf("name"))).exists(_.equals("Star Wars: Episode IV - A New Hope")) && Option(r.getInt(columns.indexOf("running_time"))).exists(_.equals(121)))
+          expectedDs = expectedWideNodes.filter(r => Option(r.getString(columns.indexOf("name"))).exists(_.equals("Star Wars: Episode IV - A New Hope")) && Option(r.getLong(columns.indexOf("running_time"))).exists(_.equals(121L)))
         )
 
-        val expected = expectedWideNodes.filter(r => Option(r.getString(columns.indexOf("name"))).exists(_.equals("Luke Skywalker")) && (if (r.isNullAt(columns.indexOf("running_time"))) None else Some(r.getInt(columns.indexOf("running_time")))).exists(_.equals(121)))
+        val expected = expectedWideNodes.filter(r => Option(r.getString(columns.indexOf("name"))).exists(_.equals("Luke Skywalker")) && (if (r.isNullAt(columns.indexOf("running_time"))) None else Some(r.getLong(columns.indexOf("running_time")))).exists(_.equals(121)))
         assert(expected.isEmpty, "expect empty result for this query, check query")
         doTestFilterPushDown(wideNodes,
           $"name" === "Luke Skywalker" && $"running_time" === 121,
@@ -630,6 +575,88 @@ class TestNodeSource extends FunSpec
 
     }
 
+    it("should provide expected wide nodes") {
+      expecteds.getExpectedTypedNodeDf(spark).show(false)
+    }
+
   }
+
+}
+
+case class NodesSourceExpecteds(cluster: DgraphCluster) {
+
+  def getDataFrame[T <: Product : TypeTag](rows: Set[T], spark: SparkSession): DataFrame =
+    spark.createDataset(rows.toSeq)(Encoders.product[T]).toDF()
+
+  def getExpectedTypedNodeDf(spark: SparkSession): DataFrame =
+    getDataFrame(getExpectedTypedNodes, spark)(typeTag[TypedNode])
+
+  def getExpectedTypedNodes: Set[TypedNode] =
+    Set(
+      TypedNode(cluster.graphQlSchema, "dgraph.type", Some("dgraph.graphql"), None, None, None, None, None, None, "string"),
+      TypedNode(cluster.graphQlSchema, "dgraph.graphql.xid", Some("dgraph.graphql.schema"), None, None, None, None, None, None, "string"),
+      TypedNode(cluster.graphQlSchema, "dgraph.graphql.schema", Some(""), None, None, None, None, None, None, "string"),
+      TypedNode(cluster.st1, "dgraph.type", Some("Film"), None, None, None, None, None, None, "string"),
+      TypedNode(cluster.st1, "name", Some("Star Trek: The Motion Picture"), None, None, None, None, None, None, "string"),
+      TypedNode(cluster.st1, "release_date", None, None, None, Some(Timestamp.valueOf("1979-12-07 00:00:00.0")), None, None, None, "timestamp"),
+      TypedNode(cluster.st1, "revenue", None, None, Some(1.39E8), None, None, None, None, "double"),
+      TypedNode(cluster.st1, "running_time", None, Some(132L), None, None, None, None, None, "long"),
+      TypedNode(cluster.leia, "dgraph.type", Some("Person"), None, None, None, None, None, None, "string"),
+      TypedNode(cluster.leia, "name", Some("Princess Leia"), None, None, None, None, None, None, "string"),
+      TypedNode(cluster.lucas, "dgraph.type", Some("Person"), None, None, None, None, None, None, "string"),
+      TypedNode(cluster.lucas, "name", Some("George Lucas"), None, None, None, None, None, None, "string"),
+      TypedNode(cluster.irvin, "dgraph.type", Some("Person"), None, None, None, None, None, None, "string"),
+      TypedNode(cluster.irvin, "name", Some("Irvin Kernshner"), None, None, None, None, None, None, "string"),
+      TypedNode(cluster.sw1, "dgraph.type", Some("Film"), None, None, None, None, None, None, "string"),
+      TypedNode(cluster.sw1, "name", Some("Star Wars: Episode IV - A New Hope"), None, None, None, None, None, None, "string"),
+      TypedNode(cluster.sw1, "release_date", None, None, None, Some(Timestamp.valueOf("1977-05-25 00:00:00.0")), None, None, None, "timestamp"),
+      TypedNode(cluster.sw1, "revenue", None, None, Some(7.75E8), None, None, None, None, "double"),
+      TypedNode(cluster.sw1, "running_time", None, Some(121L), None, None, None, None, None, "long"),
+      TypedNode(cluster.sw2, "dgraph.type", Some("Film"), None, None, None, None, None, None, "string"),
+      TypedNode(cluster.sw2, "name", Some("Star Wars: Episode V - The Empire Strikes Back"), None, None, None, None, None, None, "string"),
+      TypedNode(cluster.sw2, "release_date", None, None, None, Some(Timestamp.valueOf("1980-05-21 00:00:00.0")), None, None, None, "timestamp"),
+      TypedNode(cluster.sw2, "revenue", None, None, Some(5.34E8), None, None, None, None, "double"),
+      TypedNode(cluster.sw2, "running_time", None, Some(124L), None, None, None, None, None, "long"),
+      TypedNode(cluster.luke, "dgraph.type", Some("Person"), None, None, None, None, None, None, "string"),
+      TypedNode(cluster.luke, "name", Some("Luke Skywalker"), None, None, None, None, None, None, "string"),
+      TypedNode(cluster.han, "dgraph.type", Some("Person"), None, None, None, None, None, None, "string"),
+      TypedNode(cluster.han, "name", Some("Han Solo"), None, None, None, None, None, None, "string"),
+      TypedNode(cluster.richard, "dgraph.type", Some("Person"), None, None, None, None, None, None, "string"),
+      TypedNode(cluster.richard, "name", Some("Richard Marquand"), None, None, None, None, None, None, "string"),
+      TypedNode(cluster.sw3, "dgraph.type", Some("Film"), None, None, None, None, None, None, "string"),
+      TypedNode(cluster.sw3, "name", Some("Star Wars: Episode VI - Return of the Jedi"), None, None, None, None, None, None, "string"),
+      TypedNode(cluster.sw3, "release_date", None, None, None, Some(Timestamp.valueOf("1983-05-25 00:00:00.0")), None, None, None, "timestamp"),
+      TypedNode(cluster.sw3, "revenue", None, None, Some(5.72E8), None, None, None, None, "double"),
+      TypedNode(cluster.sw3, "running_time", None, Some(131L), None, None, None, None, None, "long"),
+    )
+
+  def getExpectedWideNodeSchema: StructType = StructType(Seq(
+    StructField("subject", LongType, nullable = false),
+    StructField("dgraph.graphql.schema", StringType, nullable = true),
+    StructField("dgraph.graphql.xid", StringType, nullable = true),
+    StructField("dgraph.type", StringType, nullable = true),
+    StructField("name", StringType, nullable = true),
+    StructField("release_date", TimestampType, nullable = true),
+    StructField("revenue", DoubleType, nullable = true),
+    StructField("running_time", LongType, nullable = true)
+  ))
+
+  def getExpectedWideNodeDf(spark: SparkSession): DataFrame =
+    spark.createDataset(getExpectedWideNodes.toSeq)(RowEncoder(getExpectedWideNodeSchema)).toDF()
+
+  def getExpectedWideNodes: Set[Row] =
+    Set(
+      Row(cluster.graphQlSchema, "", "dgraph.graphql.schema", "dgraph.graphql", null, null, null, null),
+      Row(cluster.st1, null, null, "Film", "Star Trek: The Motion Picture", Timestamp.valueOf("1979-12-07 00:00:00.0"), 1.39E8, 132L),
+      Row(cluster.leia, null, null, "Person", "Princess Leia", null, null, null),
+      Row(cluster.lucas, null, null, "Person", "George Lucas", null, null, null),
+      Row(cluster.irvin, null, null, "Person", "Irvin Kernshner", null, null, null),
+      Row(cluster.sw1, null, null, "Film", "Star Wars: Episode IV - A New Hope", Timestamp.valueOf("1977-05-25 00:00:00.0"), 7.75E8, 121L),
+      Row(cluster.sw2, null, null, "Film", "Star Wars: Episode V - The Empire Strikes Back", Timestamp.valueOf("1980-05-21 00:00:00.0"), 5.34E8, 124L),
+      Row(cluster.luke, null, null, "Person", "Luke Skywalker", null, null, null),
+      Row(cluster.han, null, null, "Person", "Han Solo", null, null, null),
+      Row(cluster.richard, null, null, "Person", "Richard Marquand", null, null, null),
+      Row(cluster.sw3, null, null, "Film", "Star Wars: Episode VI - Return of the Jedi", Timestamp.valueOf("1983-05-25 00:00:00.0"), 5.72E8, 131L)
+    )
 
 }

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/graphframes/TestGraphFrames.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/graphframes/TestGraphFrames.scala
@@ -54,64 +54,64 @@ class TestGraphFrames extends FunSpec
 
       val expected = Set(
         Row(
-          Row(sw1, null, null, "Film", "Star Wars: Episode IV - A New Hope", Timestamp.valueOf("1977-05-25 00:00:00.0"), 7.75E8, 121, 0.8118081180811808.toFloat),
-          Row(sw1, leia, "starring", 0.25),
-          Row(leia, null, null, "Person", "Princess Leia", null, null, null, 1.3293357933579335.toFloat),
+          Row(dgraph.sw1, null, null, "Film", "Star Wars: Episode IV - A New Hope", Timestamp.valueOf("1977-05-25 00:00:00.0"), 7.75E8, 121, 0.8118081180811808.toFloat),
+          Row(dgraph.sw1, dgraph.leia, "starring", 0.25),
+          Row(dgraph.leia, null, null, "Person", "Princess Leia", null, null, null, 1.3293357933579335.toFloat),
         ),
         Row(
-          Row(sw2, null, null, "Film", "Star Wars: Episode V - The Empire Strikes Back", Timestamp.valueOf("1980-05-21 00:00:00.0"), 5.34E8, 124, 0.8118081180811808.toFloat),
-          Row(sw2, leia, "starring", 0.25),
-          Row(leia, null, null, "Person", "Princess Leia", null, null, null, 1.3293357933579335.toFloat),
+          Row(dgraph.sw2, null, null, "Film", "Star Wars: Episode V - The Empire Strikes Back", Timestamp.valueOf("1980-05-21 00:00:00.0"), 5.34E8, 124, 0.8118081180811808.toFloat),
+          Row(dgraph.sw2, dgraph.leia, "starring", 0.25),
+          Row(dgraph.leia, null, null, "Person", "Princess Leia", null, null, null, 1.3293357933579335.toFloat),
         ),
         Row(
-          Row(sw3, null, null, "Film", "Star Wars: Episode VI - Return of the Jedi", Timestamp.valueOf("1983-05-25 00:00:00.0"), 5.72E8, 131, 0.8118081180811808.toFloat),
-          Row(sw3, leia, "starring", 0.25),
-          Row(leia, null, null, "Person", "Princess Leia", null, null, null, 1.3293357933579335.toFloat),
+          Row(dgraph.sw3, null, null, "Film", "Star Wars: Episode VI - Return of the Jedi", Timestamp.valueOf("1983-05-25 00:00:00.0"), 5.72E8, 131, 0.8118081180811808.toFloat),
+          Row(dgraph.sw3, dgraph.leia, "starring", 0.25),
+          Row(dgraph.leia, null, null, "Person", "Princess Leia", null, null, null, 1.3293357933579335.toFloat),
         ),
         Row(
-          Row(sw2, null, null, "Film", "Star Wars: Episode V - The Empire Strikes Back", Timestamp.valueOf("1980-05-21 00:00:00.0"), 5.34E8, 124, 0.8118081180811808.toFloat),
-          Row(sw2, irvin, "director", 0.25),
-          Row(irvin, null, null, "Person", "Irvin Kernshner", null, null, null, 0.9843173431734319.toFloat),
+          Row(dgraph.sw2, null, null, "Film", "Star Wars: Episode V - The Empire Strikes Back", Timestamp.valueOf("1980-05-21 00:00:00.0"), 5.34E8, 124, 0.8118081180811808.toFloat),
+          Row(dgraph.sw2, dgraph.irvin, "director", 0.25),
+          Row(dgraph.irvin, null, null, "Person", "Irvin Kernshner", null, null, null, 0.9843173431734319.toFloat),
         ),
         Row(
-          Row(sw1, null, null, "Film", "Star Wars: Episode IV - A New Hope", Timestamp.valueOf("1977-05-25 00:00:00.0"), 7.75E8, 121, 0.8118081180811808.toFloat),
-          Row(sw1, han, "starring", 0.25),
-          Row(han, null, null, "Person", "Han Solo", null, null, null, 1.3293357933579335.toFloat),
+          Row(dgraph.sw1, null, null, "Film", "Star Wars: Episode IV - A New Hope", Timestamp.valueOf("1977-05-25 00:00:00.0"), 7.75E8, 121, 0.8118081180811808.toFloat),
+          Row(dgraph.sw1, dgraph.han, "starring", 0.25),
+          Row(dgraph.han, null, null, "Person", "Han Solo", null, null, null, 1.3293357933579335.toFloat),
         ),
         Row(
-          Row(sw2, null, null, "Film", "Star Wars: Episode V - The Empire Strikes Back", Timestamp.valueOf("1980-05-21 00:00:00.0"), 5.34E8, 124, 0.8118081180811808.toFloat),
-          Row(sw2, han, "starring", 0.25),
-          Row(han, null, null, "Person", "Han Solo", null, null, null, 1.3293357933579335.toFloat),
+          Row(dgraph.sw2, null, null, "Film", "Star Wars: Episode V - The Empire Strikes Back", Timestamp.valueOf("1980-05-21 00:00:00.0"), 5.34E8, 124, 0.8118081180811808.toFloat),
+          Row(dgraph.sw2, dgraph.han, "starring", 0.25),
+          Row(dgraph.han, null, null, "Person", "Han Solo", null, null, null, 1.3293357933579335.toFloat),
         ),
         Row(
-          Row(sw3, null, null, "Film", "Star Wars: Episode VI - Return of the Jedi", Timestamp.valueOf("1983-05-25 00:00:00.0"), 5.72E8, 131, 0.8118081180811808.toFloat),
-          Row(sw3, han, "starring", 0.25),
-          Row(han, null, null, "Person", "Han Solo", null, null, null, 1.3293357933579335.toFloat),
+          Row(dgraph.sw3, null, null, "Film", "Star Wars: Episode VI - Return of the Jedi", Timestamp.valueOf("1983-05-25 00:00:00.0"), 5.72E8, 131, 0.8118081180811808.toFloat),
+          Row(dgraph.sw3, dgraph.han, "starring", 0.25),
+          Row(dgraph.han, null, null, "Person", "Han Solo", null, null, null, 1.3293357933579335.toFloat),
         ),
         Row(
-          Row(sw1, null, null, "Film", "Star Wars: Episode IV - A New Hope", Timestamp.valueOf("1977-05-25 00:00:00.0"), 7.75E8, 121, 0.8118081180811808.toFloat),
-          Row(sw1, lucas, "director", 0.25),
-          Row(lucas, null, null, "Person", "George Lucas", null, null, null, 0.9843173431734319.toFloat),
+          Row(dgraph.sw1, null, null, "Film", "Star Wars: Episode IV - A New Hope", Timestamp.valueOf("1977-05-25 00:00:00.0"), 7.75E8, 121, 0.8118081180811808.toFloat),
+          Row(dgraph.sw1, dgraph.lucas, "director", 0.25),
+          Row(dgraph.lucas, null, null, "Person", "George Lucas", null, null, null, 0.9843173431734319.toFloat),
         ),
         Row(
-          Row(sw1, null, null, "Film", "Star Wars: Episode IV - A New Hope", Timestamp.valueOf("1977-05-25 00:00:00.0"), 7.75E8, 121, 0.8118081180811808.toFloat),
-          Row(sw1, luke, "starring", 0.25),
-          Row(luke, null, null, "Person", "Luke Skywalker", null, null, null, 1.3293357933579335.toFloat),
+          Row(dgraph.sw1, null, null, "Film", "Star Wars: Episode IV - A New Hope", Timestamp.valueOf("1977-05-25 00:00:00.0"), 7.75E8, 121, 0.8118081180811808.toFloat),
+          Row(dgraph.sw1, dgraph.luke, "starring", 0.25),
+          Row(dgraph.luke, null, null, "Person", "Luke Skywalker", null, null, null, 1.3293357933579335.toFloat),
         ),
         Row(
-          Row(sw2, null, null, "Film", "Star Wars: Episode V - The Empire Strikes Back", Timestamp.valueOf("1980-05-21 00:00:00.0"), 5.34E8, 124, 0.8118081180811808.toFloat),
-          Row(sw2, luke, "starring", 0.25),
-          Row(luke, null, null, "Person", "Luke Skywalker", null, null, null, 1.3293357933579335.toFloat),
+          Row(dgraph.sw2, null, null, "Film", "Star Wars: Episode V - The Empire Strikes Back", Timestamp.valueOf("1980-05-21 00:00:00.0"), 5.34E8, 124, 0.8118081180811808.toFloat),
+          Row(dgraph.sw2, dgraph.luke, "starring", 0.25),
+          Row(dgraph.luke, null, null, "Person", "Luke Skywalker", null, null, null, 1.3293357933579335.toFloat),
         ),
         Row(
-          Row(sw3, null, null, "Film", "Star Wars: Episode VI - Return of the Jedi", Timestamp.valueOf("1983-05-25 00:00:00.0"), 5.72E8, 131, 0.8118081180811808.toFloat),
-          Row(sw3, luke, "starring", 0.25),
-          Row(luke, null, null, "Person", "Luke Skywalker", null, null, null, 1.3293357933579335.toFloat),
+          Row(dgraph.sw3, null, null, "Film", "Star Wars: Episode VI - Return of the Jedi", Timestamp.valueOf("1983-05-25 00:00:00.0"), 5.72E8, 131, 0.8118081180811808.toFloat),
+          Row(dgraph.sw3, dgraph.luke, "starring", 0.25),
+          Row(dgraph.luke, null, null, "Person", "Luke Skywalker", null, null, null, 1.3293357933579335.toFloat),
         ),
         Row(
-          Row(sw3, null, null, "Film", "Star Wars: Episode VI - Return of the Jedi", Timestamp.valueOf("1983-05-25 00:00:00.0"), 5.72E8, 131, 0.8118081180811808.toFloat),
-          Row(sw3, richard, "director", 0.25),
-          Row(richard, null, null, "Person", "Richard Marquand", null, null, null, 0.9843173431734319.toFloat),
+          Row(dgraph.sw3, null, null, "Film", "Star Wars: Episode VI - Return of the Jedi", Timestamp.valueOf("1983-05-25 00:00:00.0"), 5.72E8, 131, 0.8118081180811808.toFloat),
+          Row(dgraph.sw3, dgraph.richard, "director", 0.25),
+          Row(dgraph.richard, null, null, "Person", "Richard Marquand", null, null, null, 0.9843173431734319.toFloat),
         )
       )
       assert(triplets === expected)
@@ -120,17 +120,17 @@ class TestGraphFrames extends FunSpec
     def doVerticesTest(load: () => DataFrame): Unit = {
       val vertices = load().collect().toSet
       val expected = Set(
-        Row(graphQlSchema, "", "dgraph.graphql.schema", "dgraph.graphql", null, null, null, null),
-        Row(st1, null, null, "Film", "Star Trek: The Motion Picture", Timestamp.valueOf("1979-12-07 00:00:00.0"), 1.39E8, 132),
-        Row(leia, null, null, "Person", "Princess Leia", null, null, null),
-        Row(lucas, null, null, "Person", "George Lucas", null, null, null),
-        Row(irvin, null, null, "Person", "Irvin Kernshner", null, null, null),
-        Row(sw1, null, null, "Film", "Star Wars: Episode IV - A New Hope", Timestamp.valueOf("1977-05-25 00:00:00.0"), 7.75E8, 121),
-        Row(sw2, null, null, "Film", "Star Wars: Episode V - The Empire Strikes Back", Timestamp.valueOf("1980-05-21 00:00:00.0"), 5.34E8, 124),
-        Row(luke, null, null, "Person", "Luke Skywalker", null, null, null),
-        Row(han, null, null, "Person", "Han Solo", null, null, null),
-        Row(richard, null, null, "Person", "Richard Marquand", null, null, null),
-        Row(sw3, null, null, "Film", "Star Wars: Episode VI - Return of the Jedi", Timestamp.valueOf("1983-05-25 00:00:00.0"), 5.72E8, 131)
+        Row(dgraph.graphQlSchema, "", "dgraph.graphql.schema", "dgraph.graphql", null, null, null, null),
+        Row(dgraph.st1, null, null, "Film", "Star Trek: The Motion Picture", Timestamp.valueOf("1979-12-07 00:00:00.0"), 1.39E8, 132),
+        Row(dgraph.leia, null, null, "Person", "Princess Leia", null, null, null),
+        Row(dgraph.lucas, null, null, "Person", "George Lucas", null, null, null),
+        Row(dgraph.irvin, null, null, "Person", "Irvin Kernshner", null, null, null),
+        Row(dgraph.sw1, null, null, "Film", "Star Wars: Episode IV - A New Hope", Timestamp.valueOf("1977-05-25 00:00:00.0"), 7.75E8, 121),
+        Row(dgraph.sw2, null, null, "Film", "Star Wars: Episode V - The Empire Strikes Back", Timestamp.valueOf("1980-05-21 00:00:00.0"), 5.34E8, 124),
+        Row(dgraph.luke, null, null, "Person", "Luke Skywalker", null, null, null),
+        Row(dgraph.han, null, null, "Person", "Han Solo", null, null, null),
+        Row(dgraph.richard, null, null, "Person", "Richard Marquand", null, null, null),
+        Row(dgraph.sw3, null, null, "Film", "Star Wars: Episode VI - Return of the Jedi", Timestamp.valueOf("1983-05-25 00:00:00.0"), 5.72E8, 131)
       )
       assert(vertices === expected)
     }
@@ -138,25 +138,25 @@ class TestGraphFrames extends FunSpec
     def doEdgesTest(load: () => DataFrame): Unit = {
       val edges = load().collect().toSet
       val expected = Set(
-        Row(sw1, leia, "starring"),
-        Row(sw1, lucas, "director"),
-        Row(sw1, luke, "starring"),
-        Row(sw1, han, "starring"),
-        Row(sw2, leia, "starring"),
-        Row(sw2, irvin, "director"),
-        Row(sw2, luke, "starring"),
-        Row(sw2, han, "starring"),
-        Row(sw3, leia, "starring"),
-        Row(sw3, luke, "starring"),
-        Row(sw3, han, "starring"),
-        Row(sw3, richard, "director")
+        Row(dgraph.sw1, dgraph.leia, "starring"),
+        Row(dgraph.sw1, dgraph.lucas, "director"),
+        Row(dgraph.sw1, dgraph.luke, "starring"),
+        Row(dgraph.sw1, dgraph.han, "starring"),
+        Row(dgraph.sw2, dgraph.leia, "starring"),
+        Row(dgraph.sw2, dgraph.irvin, "director"),
+        Row(dgraph.sw2, dgraph.luke, "starring"),
+        Row(dgraph.sw2, dgraph.han, "starring"),
+        Row(dgraph.sw3, dgraph.leia, "starring"),
+        Row(dgraph.sw3, dgraph.luke, "starring"),
+        Row(dgraph.sw3, dgraph.han, "starring"),
+        Row(dgraph.sw3, dgraph.richard, "director")
       )
       assert(edges === expected)
     }
 
     Seq(
-      ("target", () => Seq(cluster.grpc)),
-      ("targets", () => Seq(cluster.grpc, cluster.grpcLocalIp))
+      ("target", () => Seq(dgraph.target)),
+      ("targets", () => Seq(dgraph.target, dgraph.targetLocalIp))
     ).foreach{case (test, targets) =>
 
       it(s"should load dgraph from $test via implicit session") {
@@ -164,7 +164,7 @@ class TestGraphFrames extends FunSpec
       }
 
       it(s"should load dgraph from $test via reader") {
-        doGraphTest(() => spark.read.dgraph(targets(): _*))
+        doGraphTest(() => spark.read.dgraph.graphframes(targets(): _*))
       }
 
       it(s"should load vertices from $test via implicit session") {
@@ -172,7 +172,7 @@ class TestGraphFrames extends FunSpec
       }
 
       it(s"should load vertices from $test via reader") {
-        doVerticesTest(() => spark.read.dgraphVertices(targets(): _*))
+        doVerticesTest(() => spark.read.dgraph.vertices(targets(): _*))
       }
 
       it(s"should load edges from $test via implicit session") {
@@ -180,7 +180,7 @@ class TestGraphFrames extends FunSpec
       }
 
       it(s"should load edges from $test via reader") {
-        doEdgesTest(() => spark.read.dgraphEdges(targets(): _*))
+        doEdgesTest(() => spark.read.dgraph.edges(targets(): _*))
       }
 
     }

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/graphx/TestGraphX.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/graphx/TestGraphX.scala
@@ -35,17 +35,17 @@ class TestGraphX extends FunSpec
       val pageRank = graph.pageRank(0.0001)
       val vertices = pageRank.vertices.collect().map(t => (t._1, t._2.toFloat)).toSet
       val expected = Set(
-        (graphQlSchema,0.8118081180811808),
-        (st1,0.8118081180811808),
-        (leia,1.3293357933579335),
-        (lucas,0.9843173431734319),
-        (irvin,0.9843173431734319),
-        (sw1,0.8118081180811808),
-        (sw2,0.8118081180811808),
-        (luke,1.3293357933579335),
-        (han,1.3293357933579335),
-        (richard,0.9843173431734319),
-        (sw3,0.8118081180811808),
+        (dgraph.graphQlSchema,0.8118081180811808),
+        (dgraph.st1,0.8118081180811808),
+        (dgraph.leia,1.3293357933579335),
+        (dgraph.lucas,0.9843173431734319),
+        (dgraph.irvin,0.9843173431734319),
+        (dgraph.sw1,0.8118081180811808),
+        (dgraph.sw2,0.8118081180811808),
+        (dgraph.luke,1.3293357933579335),
+        (dgraph.han,1.3293357933579335),
+        (dgraph.richard,0.9843173431734319),
+        (dgraph.sw3,0.8118081180811808),
       ).map(t => (t._1, t._2.toFloat))
       assert(vertices === expected)
     }
@@ -53,41 +53,41 @@ class TestGraphX extends FunSpec
     def doVertexTest(load: () => RDD[(graphx.VertexId, VertexProperty)]): Unit = {
       val vertices = load().collect().toSet
       val expected = Set(
-        (graphQlSchema,StringVertexProperty("dgraph.type", "dgraph.graphql")),
-        (graphQlSchema,StringVertexProperty("dgraph.graphql.xid", "dgraph.graphql.schema")),
-        (graphQlSchema,StringVertexProperty("dgraph.graphql.schema", "")),
-        (st1, StringVertexProperty("dgraph.type", "Film")),
-        (st1, StringVertexProperty("name", "Star Trek: The Motion Picture")),
-        (st1, TimestampVertexProperty("release_date", Timestamp.valueOf("1979-12-07 00:00:00.0"))),
-        (st1, DoubleVertexProperty("revenue", 1.39E8)),
-        (st1, LongVertexProperty("running_time", 132)),
-        (leia, StringVertexProperty("dgraph.type", "Person")),
-        (leia, StringVertexProperty("name", "Princess Leia")),
-        (lucas, StringVertexProperty("dgraph.type", "Person")),
-        (lucas, StringVertexProperty("name", "George Lucas")),
-        (irvin, StringVertexProperty("dgraph.type", "Person")),
-        (irvin, StringVertexProperty("name", "Irvin Kernshner")),
-        (sw1, StringVertexProperty("dgraph.type", "Film")),
-        (sw1, StringVertexProperty("name", "Star Wars: Episode IV - A New Hope")),
-        (sw1, TimestampVertexProperty("release_date", Timestamp.valueOf("1977-05-25 00:00:00.0"))),
-        (sw1, DoubleVertexProperty("revenue", 7.75E8)),
-        (sw1, LongVertexProperty("running_time", 121)),
-        (sw2, StringVertexProperty("dgraph.type", "Film")),
-        (sw2, StringVertexProperty("name", "Star Wars: Episode V - The Empire Strikes Back")),
-        (sw2, TimestampVertexProperty("release_date", Timestamp.valueOf("1980-05-21 00:00:00.0"))),
-        (sw2, DoubleVertexProperty("revenue", 5.34E8)),
-        (sw2, LongVertexProperty("running_time", 124)),
-        (luke, StringVertexProperty("dgraph.type", "Person")),
-        (luke, StringVertexProperty("name", "Luke Skywalker")),
-        (han, StringVertexProperty("dgraph.type", "Person")),
-        (han, StringVertexProperty("name", "Han Solo")),
-        (richard, StringVertexProperty("dgraph.type", "Person")),
-        (richard, StringVertexProperty("name", "Richard Marquand")),
-        (sw3, StringVertexProperty("dgraph.type", "Film")),
-        (sw3, StringVertexProperty("name", "Star Wars: Episode VI - Return of the Jedi")),
-        (sw3, TimestampVertexProperty("release_date", Timestamp.valueOf("1983-05-25 00:00:00.0"))),
-        (sw3, DoubleVertexProperty("revenue", 5.72E8)),
-        (sw3, LongVertexProperty("running_time", 131)),
+        (dgraph.graphQlSchema,StringVertexProperty("dgraph.type", "dgraph.graphql")),
+        (dgraph.graphQlSchema,StringVertexProperty("dgraph.graphql.xid", "dgraph.graphql.schema")),
+        (dgraph.graphQlSchema,StringVertexProperty("dgraph.graphql.schema", "")),
+        (dgraph.st1, StringVertexProperty("dgraph.type", "Film")),
+        (dgraph.st1, StringVertexProperty("name", "Star Trek: The Motion Picture")),
+        (dgraph.st1, TimestampVertexProperty("release_date", Timestamp.valueOf("1979-12-07 00:00:00.0"))),
+        (dgraph.st1, DoubleVertexProperty("revenue", 1.39E8)),
+        (dgraph.st1, LongVertexProperty("running_time", 132)),
+        (dgraph.leia, StringVertexProperty("dgraph.type", "Person")),
+        (dgraph.leia, StringVertexProperty("name", "Princess Leia")),
+        (dgraph.lucas, StringVertexProperty("dgraph.type", "Person")),
+        (dgraph.lucas, StringVertexProperty("name", "George Lucas")),
+        (dgraph.irvin, StringVertexProperty("dgraph.type", "Person")),
+        (dgraph.irvin, StringVertexProperty("name", "Irvin Kernshner")),
+        (dgraph.sw1, StringVertexProperty("dgraph.type", "Film")),
+        (dgraph.sw1, StringVertexProperty("name", "Star Wars: Episode IV - A New Hope")),
+        (dgraph.sw1, TimestampVertexProperty("release_date", Timestamp.valueOf("1977-05-25 00:00:00.0"))),
+        (dgraph.sw1, DoubleVertexProperty("revenue", 7.75E8)),
+        (dgraph.sw1, LongVertexProperty("running_time", 121)),
+        (dgraph.sw2, StringVertexProperty("dgraph.type", "Film")),
+        (dgraph.sw2, StringVertexProperty("name", "Star Wars: Episode V - The Empire Strikes Back")),
+        (dgraph.sw2, TimestampVertexProperty("release_date", Timestamp.valueOf("1980-05-21 00:00:00.0"))),
+        (dgraph.sw2, DoubleVertexProperty("revenue", 5.34E8)),
+        (dgraph.sw2, LongVertexProperty("running_time", 124)),
+        (dgraph.luke, StringVertexProperty("dgraph.type", "Person")),
+        (dgraph.luke, StringVertexProperty("name", "Luke Skywalker")),
+        (dgraph.han, StringVertexProperty("dgraph.type", "Person")),
+        (dgraph.han, StringVertexProperty("name", "Han Solo")),
+        (dgraph.richard, StringVertexProperty("dgraph.type", "Person")),
+        (dgraph.richard, StringVertexProperty("name", "Richard Marquand")),
+        (dgraph.sw3, StringVertexProperty("dgraph.type", "Film")),
+        (dgraph.sw3, StringVertexProperty("name", "Star Wars: Episode VI - Return of the Jedi")),
+        (dgraph.sw3, TimestampVertexProperty("release_date", Timestamp.valueOf("1983-05-25 00:00:00.0"))),
+        (dgraph.sw3, DoubleVertexProperty("revenue", 5.72E8)),
+        (dgraph.sw3, LongVertexProperty("running_time", 131)),
       )
       assert(vertices === expected)
     }
@@ -95,25 +95,25 @@ class TestGraphX extends FunSpec
     def doEdgeTest(load: () => RDD[Edge[EdgeProperty]]): Unit = {
       val edges = load().collect().toSet
       val expected = Set(
-        Edge(sw1, leia, EdgeProperty("starring")),
-        Edge(sw1, lucas, EdgeProperty("director")),
-        Edge(sw1, luke, EdgeProperty("starring")),
-        Edge(sw1, han, EdgeProperty("starring")),
-        Edge(sw2, leia, EdgeProperty("starring")),
-        Edge(sw2, irvin, EdgeProperty("director")),
-        Edge(sw2, luke, EdgeProperty("starring")),
-        Edge(sw2, han, EdgeProperty("starring")),
-        Edge(sw3, leia, EdgeProperty("starring")),
-        Edge(sw3, luke, EdgeProperty("starring")),
-        Edge(sw3, han, EdgeProperty("starring")),
-        Edge(sw3, richard, EdgeProperty("director")),
+        Edge(dgraph.sw1, dgraph.leia, EdgeProperty("starring")),
+        Edge(dgraph.sw1, dgraph.lucas, EdgeProperty("director")),
+        Edge(dgraph.sw1, dgraph.luke, EdgeProperty("starring")),
+        Edge(dgraph.sw1, dgraph.han, EdgeProperty("starring")),
+        Edge(dgraph.sw2, dgraph.leia, EdgeProperty("starring")),
+        Edge(dgraph.sw2, dgraph.irvin, EdgeProperty("director")),
+        Edge(dgraph.sw2, dgraph.luke, EdgeProperty("starring")),
+        Edge(dgraph.sw2, dgraph.han, EdgeProperty("starring")),
+        Edge(dgraph.sw3, dgraph.leia, EdgeProperty("starring")),
+        Edge(dgraph.sw3, dgraph.luke, EdgeProperty("starring")),
+        Edge(dgraph.sw3, dgraph.han, EdgeProperty("starring")),
+        Edge(dgraph.sw3, dgraph.richard, EdgeProperty("director")),
       )
       assert(edges === expected)
     }
 
     Seq(
-      ("target", () => Seq(cluster.grpc)),
-      ("targets", () => Seq(cluster.grpc, cluster.grpcLocalIp))
+      ("target", () => Seq(dgraph.target)),
+      ("targets", () => Seq(dgraph.target, dgraph.targetLocalIp))
     ).foreach{case (test, targets) =>
 
       it(s"should load dgraph from $test via implicit session") {
@@ -121,7 +121,7 @@ class TestGraphX extends FunSpec
       }
 
       it(s"should load dgraph from $test via reader") {
-        doGraphTest(() => spark.read.dgraph(targets(): _*))
+        doGraphTest(() => spark.read.dgraph.graphx(targets(): _*))
       }
 
       it(s"should load vertices from $test via implicit session") {
@@ -129,7 +129,7 @@ class TestGraphX extends FunSpec
       }
 
       it(s"should load vertices from $test via reader") {
-        doVertexTest(() => spark.read.dgraphVertices(targets(): _*))
+        doVertexTest(() => spark.read.dgraph.vertices(targets(): _*))
       }
 
       it(s"should load edges from $test via implicit session") {
@@ -137,7 +137,7 @@ class TestGraphX extends FunSpec
       }
 
       it(s"should load edges from $test via reader") {
-        doEdgeTest(() => spark.read.dgraphEdges(targets(): _*))
+        doEdgeTest(() => spark.read.dgraph.edges(targets(): _*))
       }
 
     }


### PR DESCRIPTION
- Replaced spark.read.dgraph* methods with spark.read.dgraph.*
- Moved default sources from uk.co.gresearch.spark.dgraph.connector to uk.co.gresearch.spark.dgraph
- Made test cluster target available through DgraphCluster, not through its cluster attribute
- Reworked Dgraph test cluster naming and code structure
- Move test expect data into separate classes
- Updated README.md