### PR TITLE
Add caching for pip and mvn in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Cache pip packages
+    - name: Cache Pip packages
       uses: actions/cache@v2
       with:
         path: ~/.cache/pip
@@ -28,7 +28,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-packages-${{ matrix.python-version }}-
 
-    - name: Cache maven packages
+    - name: Cache Maven packages
       uses: actions/cache@v2
       with:
         path: ~/.m2/repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,22 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
+    - name: Cache pip packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-packages-${{ matrix.python-version }}-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-packages-${{ matrix.python-version }}-
+
+    - name: Cache maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-mvn-packages-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-mvn-packages-
+
     - name: Setup JDK 1.8
       uses: actions/setup-java@v1
       with:


### PR DESCRIPTION
Reduces build and test step from 6m 30s to 2m 30s, running 3 times each commit.