### PR TITLE
Make read transaction optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [UNRELEASED] - YYYY-MM-DD
 
 ### Added
-- Reads all partitions within the same transaction. This guarantees a consistent snapshot of the graph ([issue #6](https://github.com/G-Research/spark-dgraph-connector/issues/6)).
-  However, concurrent mutations can reduce the lifetime of a transaction.
+- Optionally reads all partitions within the same transaction. This guarantees a consistent snapshot of the graph ([issue #6](https://github.com/G-Research/spark-dgraph-connector/issues/6)).
+  However, concurrent mutations reduce the lifetime of such a transaction and will cause an exception when lifespan exceeds.
 - Add Python API that mirrors the Scala API. The README.md fully documents how to load Dgraph data in PySpark.
 - Fixed dependency conflicts between connector dependencies and Spark
   by shading the Java Dgraph client and all its dependencies.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ nodes: DataFrame = spark.read.dgraph.nodes("localhost:9080")
 The connector is under continuous development. It has the following known limitations:
 
 - **Read-only**: The connector does not support mutating the graph ([issue #8](https://github.com/G-Research/spark-dgraph-connector/issues/8)).
-- **Limited Lifetime of Transactions**: The connector reads all partitions within the same transaction, but concurrent mutations can reduce the lifetime of that transaction.
+- **Limited Lifetime of Transactions**: The connector optionally reads all partitions within the same transaction, but concurrent mutations reduce the lifetime of that transaction.
 - **Language tags & facets**: The connector cannot read any string values with language tags or facets.
 
 Beside the **language tags & facets**, which is a limitation of Dgraph, all the other issues mentioned
@@ -380,6 +380,17 @@ Though there is only a single `object` column for the destination node, it is ca
 |10     |starring |2        |
 |10     |starring |6        |
 |10     |director |8        |
+
+## Transactions
+
+Dgraph isolates reads from writes through transactions. Since the connector initiates multiple reads
+while fetching the entire graph (partitioning), writes called [mutations](https://dgraph.io/docs/mutations/)
+should be isolated in order to get a consistent snapshot of the graph.
+
+Setting the `dgraph.transaction.mode` option to `"read"` will cause the connector to read all partitions
+within the same transaction. However, this will cause an exception on the Dgraph cluster when too many
+mutations occur while reading partitions. With that option set to `"none"`, no such exception will
+occur but reads are not isolated from writes.
 
 ## Filter Pushdown
 

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/executor/DgraphExecutorProvider.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/executor/DgraphExecutorProvider.scala
@@ -17,7 +17,7 @@
 package uk.co.gresearch.spark.dgraph.connector.executor
 import uk.co.gresearch.spark.dgraph.connector.{Partition, Transaction}
 
-case class DgraphExecutorProvider(transaction: Transaction) extends ExecutorProvider {
+case class DgraphExecutorProvider(transaction: Option[Transaction]) extends ExecutorProvider {
 
   /**
    * Provide an executor for the given partition.

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/package.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/package.scala
@@ -162,6 +162,11 @@ package object connector {
   val NodesModeTypedOption: String = "typed"
   val NodesModeWideOption: String = "wide"
 
+  val TransactionModeOption: String = "dgraph.transaction.mode"
+  val TransactionModeNoneOption: String = "none"
+  val TransactionModeReadOption: String = "read"
+  val TransactionModeDefault: String = TransactionModeNoneOption
+
   val ChunkSizeOption: String = "dgraph.chunkSize"
   val ChunkSizeDefault: Int = 100000
 

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/ConfigPartitionerOption.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/ConfigPartitionerOption.scala
@@ -26,7 +26,7 @@ class ConfigPartitionerOption extends PartitionerProviderOption
 
   override def getPartitioner(schema: Schema,
                               clusterState: ClusterState,
-                              transaction: Transaction,
+                              transaction: Option[Transaction],
                               options: CaseInsensitiveStringMap): Option[Partitioner] =
     getStringOption(PartitionerOption, options)
       .map(getPartitioner(_, schema, clusterState, transaction, options))
@@ -34,7 +34,7 @@ class ConfigPartitionerOption extends PartitionerProviderOption
   def getPartitioner(partitionerName: String,
                      schema: Schema,
                      clusterState: ClusterState,
-                     transaction: Transaction,
+                     transaction: Option[Transaction],
                      options: CaseInsensitiveStringMap): Partitioner =
     partitionerName match {
       case SingletonPartitionerOption => SingletonPartitioner(getAllClusterTargets(clusterState), schema)

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/DefaultPartitionerOption.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/DefaultPartitionerOption.scala
@@ -23,7 +23,7 @@ class DefaultPartitionerOption extends ConfigPartitionerOption {
 
   override def getPartitioner(schema: Schema,
                               clusterState: ClusterState,
-                              transaction: Transaction,
+                              transaction: Option[Transaction],
                               options: CaseInsensitiveStringMap): Option[Partitioner] =
     Some(getPartitioner(PartitionerDefault, schema, clusterState, transaction, options))
 

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/PartitionerProvider.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/PartitionerProvider.scala
@@ -28,7 +28,7 @@ trait PartitionerProvider {
 
   def getPartitioner(schema: Schema,
                      clusterState: ClusterState,
-                     transaction: Transaction,
+                     transaction: Option[Transaction],
                      options: CaseInsensitiveStringMap): Partitioner =
     partitionerOptions
       .flatMap(_.getPartitioner(schema, clusterState, transaction, options))

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/PartitionerProviderOption.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/PartitionerProviderOption.scala
@@ -23,7 +23,7 @@ trait PartitionerProviderOption {
 
   def getPartitioner(schema: Schema,
                      clusterState: ClusterState,
-                     transaction: Transaction,
+                     transaction: Option[Transaction],
                      options: CaseInsensitiveStringMap): Option[Partitioner]
 
 }

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/sources/EdgeSource.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/sources/EdgeSource.scala
@@ -43,7 +43,7 @@ class EdgeSource() extends TableProviderBase
                         properties: util.Map[String, String]): Table = {
     val options = new CaseInsensitiveStringMap(properties)
     val targets = getTargets(options)
-    val transaction = getTransaction(targets)
+    val transaction = getTransaction(targets, options)
     val execution = DgraphExecutorProvider(transaction)
     val schema = getSchema(targets).filter(_.isEdge)
     val clusterState = getClusterState(targets)

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/sources/NodeSource.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/sources/NodeSource.scala
@@ -83,7 +83,7 @@ class NodeSource() extends TableProviderBase
     val adjustedOptions = adjustOptions(options)
 
     val targets = getTargets(adjustedOptions)
-    val transaction = getTransaction(targets)
+    val transaction = getTransaction(targets, options)
     val execution = DgraphExecutorProvider(transaction)
     val schema = getSchema(targets).filter(_.isProperty)
     val clusterState = getClusterState(targets)

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/sources/TripleSource.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/sources/TripleSource.scala
@@ -51,7 +51,7 @@ class TripleSource() extends TableProviderBase
                         properties: util.Map[String, String]): Table = {
     val options = new CaseInsensitiveStringMap(properties)
     val targets = getTargets(options)
-    val transaction = getTransaction(targets)
+    val transaction = getTransaction(targets, options)
     val execution = DgraphExecutorProvider(transaction)
     val schema = getSchema(targets)
     val clusterState = getClusterState(targets)

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/DgraphTestCluster.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/DgraphTestCluster.scala
@@ -126,7 +126,7 @@ class DgraphCluster(pathToInsertedJson: String = ".", alwaysStartUp: Boolean = f
 
     @tailrec
     def attempt(no: Int, limit: Int): Uid = {
-      val transaction = Transaction(TxnContext.newBuilder().build())
+      val transaction = Some(Transaction(TxnContext.newBuilder().build()))
       val json = DgraphExecutor(transaction, Seq(Target(target))).query(query)
       log.debug(s"retrieved dgraph.graphql.schema node: ${json.string}")
 

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestPartition.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestPartition.scala
@@ -41,7 +41,7 @@ class TestPartition extends FunSpec with SchemaProvider with DgraphTestCluster {
         val schema = Schema(syntheticPredicates ++ existingPredicates)
         val partition = Partition(targets).has(schema.predicates)
         val encoder = TypedTripleEncoder(schema.predicateMap)
-        val transaction = Transaction(TxnContext.newBuilder().build())
+        val transaction = Some(Transaction(TxnContext.newBuilder().build()))
         val execution = DgraphExecutorProvider(transaction)
         val model = TripleTableModel(execution, encoder, ChunkSizeDefault)
         assert(model.modelPartition(partition).length === 47)

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestDefaultPartitionerOption.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestDefaultPartitionerOption.scala
@@ -34,7 +34,7 @@ class TestDefaultPartitionerOption extends FunSpec {
       10000,
       UUID.randomUUID()
     )
-    val transaction = Transaction(TxnContext.newBuilder().build())
+    val transaction = Some(Transaction(TxnContext.newBuilder().build()))
     val options = CaseInsensitiveStringMap.empty()
 
     it(s"should provide a partitioner") {

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestPartitionerProvider.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestPartitionerProvider.scala
@@ -35,7 +35,7 @@ class TestPartitionerProvider extends FunSpec {
     10000,
     UUID.randomUUID()
   )
-  val transaction: Transaction = Transaction(TxnContext.newBuilder().build())
+  val transaction: Option[Transaction] = Some(Transaction(TxnContext.newBuilder().build()))
   val maxLeaseEstimator: UidCardinalityEstimator = MaxLeaseIdUidCardinalityEstimator(state.maxLeaseId)
   assert(UidRangePartitionerEstimatorDefault === MaxLeaseIdEstimatorOption, "tests assume this default estimator")
 


### PR DESCRIPTION
Makes reading the graph in a transaction optional and off by default.