### PR TITLE
Object values cannot be filtered in dgraph for multiple predicates per partition

### DIFF
--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/FilterTranslator.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/FilterTranslator.scala
@@ -170,6 +170,9 @@ object FilterTranslator {
     val promisedSimplified = simplify(filters.promised)
     val optionalSimplified = simplify(filters.optional)
 
+    // we could use allSimplified filters even if some are not supported,
+    // as long as it is guaranteed that they fully cover the promised filters
+    // but we have no way to indicate this here, which would add a bit of extra logic
     if (supported(allSimplified)) {
       Filters.from(allSimplified)
     } else {

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/PredicatePartitioner.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/PredicatePartitioner.scala
@@ -44,10 +44,12 @@ case class PredicatePartitioner(schema: Schema,
     case _: AlwaysFalse => true
     case _: SubjectIsIn => true
     case _: PredicateNameIsIn => true
-    case _: PredicateValueIsIn => true
+    // with multiple predicates in a partition we cannot filter for predicate value
+    case _: PredicateValueIsIn => predicatesPerPartition == 1
     case _: ObjectTypeIsIn => true
     // only supported together with PredicateNameIsIn or ObjectTypeIsIn
-    case _: ObjectValueIsIn => filters.exists {
+    // with multiple predicates in a partition we cannot filter for predicate value
+    case _: ObjectValueIsIn => predicatesPerPartition == 1 && filters.exists {
       case _: PredicateNameIsIn => true
       case _: ObjectTypeIsIn => true
       case _ => false

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestPartitionQuery.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestPartitionQuery.scala
@@ -184,7 +184,7 @@ class TestPartitionQuery extends AnyFunSpec {
           |    uid
           |    <edge1> { uid }
           |    <edge2> { uid } @filter(uid(0x1, 0x2))
-          |    <prop1> @filter(eq(<prop1>, "one") OR eq(<prop1>, "two"))
+          |    <prop1>
           |    <prop2>
           |  }
           |}""".stripMargin)
@@ -342,32 +342,22 @@ class TestPartitionQuery extends AnyFunSpec {
         ))
       }
 
-      it("should filter values") {
+      it("should filter edge values, not properties") {
         val query = PartitionQuery("result", hasPredicates ++ filters)
         assert(query.predicatePaths === Seq(
           "<edge1> { uid }",
           "<edge2> { uid } @filter(uid(0x1))",
-          "<prop1> @filter(eq(<prop1>, \"value\"))",
+          "<prop1>",
           "<prop2>",
         ))
       }
 
-      it("should filter multiple values") {
+      it("should filter multiple edge values, not properties") {
         val query = PartitionQuery("result", hasPredicates ++ multiValueFilters)
         assert(query.predicatePaths === Seq(
           "<edge1> { uid }",
           "<edge2> { uid } @filter(uid(0x1, 0x2))",
-          "<prop1> @filter(eq(<prop1>, \"one\") OR eq(<prop1>, \"two\"))",
-          "<prop2>",
-        ))
-      }
-
-      it("should filter multiple values per predicate") {
-        val query = PartitionQuery("result", hasPredicates ++ multiFilters)
-        assert(query.predicatePaths === Seq(
-          "<edge1> { uid }",
-          "<edge2> { uid }",
-          "<prop1> @filter(ge(<prop1>, \"1\") AND lt(<prop1>, \"2\"))",
+          "<prop1>",
           "<prop2>",
         ))
       }
@@ -380,27 +370,6 @@ class TestPartitionQuery extends AnyFunSpec {
           "<prop1>@*",
           "<prop2>",
         ))
-      }
-
-      predicateValueOperators.foreach { op =>
-        it(s"should support predicate value ${op.filter} with single predicate") {
-          val query = PartitionQuery("result", hasProp + op)
-          assert(query.predicatePaths === Seq(
-            s"""<${op.predicates.head}> @filter(${op.filter}(<${op.predicates.head}>, "${op.value}"))""",
-          ))
-        }
-      }
-
-      predicatesValueOperators.foreach { op =>
-        it(s"should support predicate value ${op.filter} with multiple predicates") {
-          val query = PartitionQuery("result", hasPredicates + op)
-          assert(query.predicatePaths === Seq(
-            "<edge1> { uid }",
-            "<edge2> { uid }",
-            s"""<${op.predicates.head}> @filter(${op.filter}(<${op.predicates.head}>, "${op.value}"))""",
-            s"""<${op.predicates.drop(1).head}> @filter(${op.filter}(<${op.predicates.drop(1).head}>, "${op.value}"))""",
-          ))
-        }
       }
 
     }


### PR DESCRIPTION
Having `@filter` on properties (scala predicates) does not have any effect. Dgraph returns all properties for a `uid` no matter the value and filter. This removes the filters from the queries for properties (not edges). `PredicatePartitioner` does not promise `EqualTo` and `IsIn` filters when multiple predicates can be in a partition.