### PR TITLE
Include more python versions for latest dgraph minor versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,21 @@ jobs:
       matrix:
         dgraph-version: [20.03.4, 20.03.5, 20.03.6, 20.03.7, 20.07.0, 20.07.1, 20.07.2, 20.11.0, 20.11.1, 20.11.2]
         python-version: [3.6]
+        include:
+          - dgraph-version: 20.03.7
+            python-version: 3.7
+          - dgraph-version: 20.03.7
+            python-version: 3.8
+
+          - dgraph-version: 20.07.2
+            python-version: 3.7
+          - dgraph-version: 20.07.2
+            python-version: 3.8
+
+          - dgraph-version: 20.11.2
+            python-version: 3.7
+          - dgraph-version: 20.11.2
+            python-version: 3.8
 
     steps:
     - name: Checkout


### PR DESCRIPTION
Adds Python 3.7 and 3.8 to latest dgraph minor version testing.