### PR TITLE
Support dgraph v21.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,12 +88,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dgraph-version: [21.09-slash]
+        dgraph-version: [20.03.4, 20.03.5, 20.03.6, 20.03.7, 20.07.0, 20.07.1, 20.07.2, 20.07.3, 20.11.0, 20.11.1, 20.11.2, 20.11.3, 21.03.0, 21.03.1, 21.03.2]
         python-version: [3.6]
         include:
-          - dgraph-version: 21.09-slash
+          - dgraph-version: 20.03.7
             python-version: 3.7
-          - dgraph-version: 21.09-slash
+          - dgraph-version: 20.03.7
+            python-version: 3.8
+
+          - dgraph-version: 20.07.3
+            python-version: 3.7
+          - dgraph-version: 20.07.3
+            python-version: 3.8
+
+          - dgraph-version: 20.11.3
+            python-version: 3.7
+          - dgraph-version: 20.11.3
+            python-version: 3.8
+
+          - dgraph-version: 21.03.2
+            python-version: 3.7
+          - dgraph-version: 21.03.2
             python-version: 3.8
 
     steps:
@@ -190,7 +205,7 @@ jobs:
       fail-fast: false
       matrix:
         spark-version: ${{ fromJSON(needs.build.outputs.spark-version-matrix) }}
-        dgraph-version: [21.09-slash]
+        dgraph-version: [20.03.7, 20.07.3, 20.11.3, 21.03.0]
         include:
           - spark-version: ${{ needs.build.outputs.spark-version }}
             spark-compat-version: ${{ needs.build.outputs.spark-compat-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dgraph-version: [20.03.4, 20.03.5, 20.03.6, 20.03.7, 20.07.0, 20.07.1, 20.07.2, 20.07.3, 20.11.0, 20.11.1, 20.11.2, 20.11.3, 21.03.0, 21.03.1, 21.03.2]
+        dgraph-version: [20.03.4, 20.03.5, 20.03.6, 20.03.7, 20.07.0, 20.07.1, 20.07.2, 20.07.3, 20.11.0, 20.11.1, 20.11.2, 20.11.3, 21.03.0, 21.03.1, 21.03.2, 21.09-slash]
         python-version: [3.6]
         include:
           - dgraph-version: 20.03.7
@@ -111,6 +111,10 @@ jobs:
           - dgraph-version: 21.03.2
             python-version: 3.8
 
+          - dgraph-version: 21.09-slash
+            python-version: 3.7
+          - dgraph-version: 21.09-slash
+            python-version: 3.8
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -205,7 +209,7 @@ jobs:
       fail-fast: false
       matrix:
         spark-version: ${{ fromJSON(needs.build.outputs.spark-version-matrix) }}
-        dgraph-version: [20.03.7, 20.07.3, 20.11.3, 21.03.0]
+        dgraph-version: [20.03.7, 20.07.3, 20.11.3, 21.03.2, 21.09-slash]
         include:
           - spark-version: ${{ needs.build.outputs.spark-version }}
             spark-compat-version: ${{ needs.build.outputs.spark-compat-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,27 +88,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dgraph-version: [20.03.4, 20.03.5, 20.03.6, 20.03.7, 20.07.0, 20.07.1, 20.07.2, 20.07.3, 20.11.0, 20.11.1, 20.11.2, 20.11.3, 21.03.0, 21.03.1, 21.03.2]
+        dgraph-version: [21.09-slash]
         python-version: [3.6]
         include:
-          - dgraph-version: 20.03.7
+          - dgraph-version: 21.09-slash
             python-version: 3.7
-          - dgraph-version: 20.03.7
-            python-version: 3.8
-
-          - dgraph-version: 20.07.3
-            python-version: 3.7
-          - dgraph-version: 20.07.3
-            python-version: 3.8
-
-          - dgraph-version: 20.11.3
-            python-version: 3.7
-          - dgraph-version: 20.11.3
-            python-version: 3.8
-
-          - dgraph-version: 21.03.2
-            python-version: 3.7
-          - dgraph-version: 21.03.2
+          - dgraph-version: 21.09-slash
             python-version: 3.8
 
     steps:
@@ -205,7 +190,7 @@ jobs:
       fail-fast: false
       matrix:
         spark-version: ${{ fromJSON(needs.build.outputs.spark-version-matrix) }}
-        dgraph-version: [20.03.7, 20.07.3, 20.11.3, 21.03.0]
+        dgraph-version: [21.09-slash]
         include:
           - spark-version: ${{ needs.build.outputs.spark-version }}
             spark-compat-version: ${{ needs.build.outputs.spark-compat-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dgraph-version: [20.03.4, 20.03.5, 20.03.6, 20.03.7, 20.07.0, 20.07.1, 20.07.2, 20.07.3, 20.11.0, 20.11.1, 20.11.2, 20.11.3, 21.03.0, 21.03.1, 21.03.2, 21.09-slash]
+        dgraph-version: [20.03.4, 20.03.5, 20.03.6, 20.03.7, 20.07.0, 20.07.1, 20.07.2, 20.07.3, 20.11.0, 20.11.1, 20.11.2, 20.11.3, 21.03.0, 21.03.1, 21.03.2, 21.12.0]
         python-version: [3.6]
         include:
           - dgraph-version: 20.03.7
@@ -111,9 +111,9 @@ jobs:
           - dgraph-version: 21.03.2
             python-version: 3.8
 
-          - dgraph-version: 21.09-slash
+          - dgraph-version: 21.12.0
             python-version: 3.7
-          - dgraph-version: 21.09-slash
+          - dgraph-version: 21.12.0
             python-version: 3.8
     steps:
     - name: Checkout
@@ -209,7 +209,7 @@ jobs:
       fail-fast: false
       matrix:
         spark-version: ${{ fromJSON(needs.build.outputs.spark-version-matrix) }}
-        dgraph-version: [20.03.7, 20.07.3, 20.11.3, 21.03.2, 21.09-slash]
+        dgraph-version: [20.03.7, 20.07.3, 20.11.3, 21.03.2, 21.12.0]
         include:
           - spark-version: ${{ needs.build.outputs.spark-version }}
             spark-compat-version: ${{ needs.build.outputs.spark-compat-version }}

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ nodes: DataFrame = spark.read.dgraph.nodes("localhost:9080")
 The connector is under continuous development. It has the following known limitations:
 
 - **Read-only**: The connector does not support mutating the graph ([issue #8](https://github.com/G-Research/spark-dgraph-connector/issues/8)).
+- **Namespaces**: The connector can only read the default namespace ([issue #148](https://github.com/G-Research/spark-dgraph-connector/issues/148)).
+- **Authorization**: No authorization against Dgraph supported ([issue #149](https://github.com/G-Research/spark-dgraph-connector/issues/149)).
 - **Limited Lifetime of Transactions**: The connector optionally reads all partitions within the same transaction, but concurrent mutations [reduce the lifetime of that transaction](#transactions).
 - **Language tags**: The node source in wide mode cannot read string values with [language tags](https://dgraph.io/docs/tutorial-4/#strings-and-languages). All other sources and modes can read language strings.
 - **Filtering on language string**: The connector does not support filtering predicates with [Dgraph `@lang` directives](https://dgraph.io/docs/tutorial-4/#strings-and-languages).

--- a/README.md
+++ b/README.md
@@ -519,7 +519,7 @@ to (selected predicates and nodes only):
       }
     }
 
-The response is faster as only relevant data are transfered between Dgraph and Spark.
+The response is faster as only relevant data are transferred between Dgraph and Spark.
 
 |subject|dgraph.type|revenue|
 |:-----:|:---------:|:-----:|
@@ -595,7 +595,7 @@ locally to the alpha nodes and induce no Dgraph cluster internal communication.
 
 #### Partitioning by Uids
 
-A `uid` represents a node or vertice in Dgraph terminology. A "Uid Range" partitioning splits
+A `uid` represents a node or vertex in Dgraph terminology. An "Uid Range" partitioning splits
 the graph by the subject of the graph triples. This can be combined with predicate partitioning,
 which serves as an orthogonal partitioning. Without predicate partitioning, `uid` partitioning
 induces internal Dgraph cluster communication across the groups.

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/ClusterState.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/ClusterState.scala
@@ -68,7 +68,11 @@ object ClusterState {
       .getOrElse(Set.empty)
       .map(_.getValue.getAsJsonObject)
       .map(_.getAsJsonPrimitive("predicate"))
-      .map(_.getAsString.replace("\u0000", ""))
+      .map(_.getAsString)
+      // v21.03 introduced these zero characters in the predicate name
+      .map(_.replace("\u0000", ""))
+      // v21.09 replaced them with a 0- prefix
+      .map(_.replaceAll("^[0-9]+-", ""))
       .toSet
 
 }

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/ClusterState.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/ClusterState.scala
@@ -67,12 +67,17 @@ object ClusterState {
       .map(_.entrySet().asScala)
       .getOrElse(Set.empty)
       .map(_.getValue.getAsJsonObject)
-      .map(_.getAsJsonPrimitive("predicate"))
-      .map(_.getAsString)
-      // v21.03 introduced these zero characters in the predicate name
-      .map(_.replace("\u0000", ""))
-      // v21.09 replaced them with a 0- prefix
-      .map(_.replaceAll("^[0-9]+-", ""))
+      .map(_.getAsJsonPrimitive("predicate").getAsString)
+
+      // v21.03 prefixes predicates with namespace id as binary
+      // this only fixes the default namespace, all other namespaces' predicates won't match the schema
+      .map(_.replaceAll("⁺\u0000+", ""))
+
+      // v21.09 prefixes predicates with namespace id plus '-'
+      // here we filter for the default or no namespace and then remove the prefix
+      .filter(predicate => predicate.startsWith("0-") || !predicate.matches("^[0-9]+-"))
+      .map(_.replaceAll("^0-", ""))
+
       .toSet
 
 }

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/ClusterStateProvider.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/ClusterStateProvider.scala
@@ -26,7 +26,7 @@ trait ClusterStateProvider extends Logging {
     val clusterStates = targets.map(getClusterState).flatten
     val cids = clusterStates.map(_.cid).toSet
     if (cids.size > 1)
-      throw new RuntimeException(s"Retrived multiple cluster ids from " +
+      throw new RuntimeException(s"Retrieved multiple cluster ids from " +
         s"Dgraph alphas (${targets.map(_.target).mkString(", ")}): ${cids.mkString(", ")}")
     val clusterState = clusterStates.headOption.getOrElse(
       throw new RuntimeException(s"Could not retrieve cluster state from Dgraph alphas (${targets.map(_.target).mkString(", ")})")


### PR DESCRIPTION
Dgraph v21.09 changed the names of tablets where 64bit binary namespace prefix was removed by string prefix. Version v21.09 has never been released, the next official release with that change is v21.12.0.