### PR TITLE
Fixing pip cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,21 +119,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - run: |
-        find
-
-    - run: |
-        find . -name requirements.txt
-
-    - run: echo "${{ hashFiles('**/requirements.txt') }}"
-
     - name: Fetch Binaries Artifact
       uses: actions/download-artifact@v2
       with:
         name: Binaries
         path: .
-
-    - run: echo "${{ hashFiles('**/requirements.txt') }}"
 
     - name: Cache Maven packages
       uses: actions/cache@v2
@@ -143,15 +133,11 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-mvn-test-
 
-    - run: echo "${{ hashFiles('**/requirements.txt') }}"
-
     - name: Setup JDK 1.8
       uses: actions/setup-java@v2
       with:
         java-version: '8'
         distribution: 'zulu'
-
-    - run: echo "${{ hashFiles('**/requirements.txt') }}"
 
     - name: Start Dgraph cluster
       id: dgraph
@@ -167,17 +153,12 @@ jobs:
         fi
         /tmp/dgraph-instance.schema.sh
         /tmp/dgraph-instance.insert.sh
-        ls -lah /tmp/
       shell: bash
-
-    - run: echo "${{ hashFiles('**/requirements.txt') }}"
 
     - name: Scala Test
       env:
         DGRAPH_TEST_CLUSTER_VERSION: ${{ matrix.dgraph-version }}
       run: mvn --batch-mode test
-
-    - run: echo "${{ hashFiles('**/requirements.txt') }}"
 
     - name: Cache Pip packages
       uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,20 +36,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - run: |
-          find
-
-      - run: |
-          find . -name requirements.txt
-
-      - name: Cache Pip packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-build-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-build-
-
       - name: Parametrize Extraction
         id: params-extract
         run: |
@@ -133,11 +119,48 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
+    - run: |
+        find
+
+    - run: |
+        find . -name requirements.txt
+
+    - run: echo "${{ hashFiles('**/requirements.txt') }}"
+
+    - name: Cache Pip packages
+      if: always()
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-build-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-build-
+
+    - name: Cache Pip packages
+      if: always()
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-build-${{ hashFiles("**/requirements.txt") }}
+        restore-keys: |
+          ${{ runner.os }}-pip-build-
+
+    - name: Cache Pip packages
+      if: always()
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-build-${{ hashFiles("python/requirements.txt") }}
+        restore-keys: |
+          ${{ runner.os }}-pip-build-
+
     - name: Fetch Binaries Artifact
       uses: actions/download-artifact@v2
       with:
         name: Binaries
         path: .
+
+    - run: echo "${{ hashFiles('**/requirements.txt') }}"
 
     - name: Cache Maven packages
       uses: actions/cache@v2
@@ -172,6 +195,8 @@ jobs:
       env:
         DGRAPH_TEST_CLUSTER_VERSION: ${{ matrix.dgraph-version }}
       run: mvn --batch-mode test
+
+    - run: echo "${{ hashFiles('**/requirements.txt') }}"
 
     - name: Cache Pip packages
       uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,24 +127,6 @@ jobs:
 
     - run: echo "${{ hashFiles('**/requirements.txt') }}"
 
-    - name: Cache Pip packages
-      if: always()
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-build-${{ hashFiles('**/requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-build-
-
-    - name: Cache Pip packages
-      if: always()
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-build-${{ hashFiles('python/requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-build-
-
     - name: Fetch Binaries Artifact
       uses: actions/download-artifact@v2
       with:
@@ -161,11 +143,15 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-mvn-test-
 
+    - run: echo "${{ hashFiles('**/requirements.txt') }}"
+
     - name: Setup JDK 1.8
       uses: actions/setup-java@v2
       with:
         java-version: '8'
         distribution: 'zulu'
+
+    - run: echo "${{ hashFiles('**/requirements.txt') }}"
 
     - name: Start Dgraph cluster
       id: dgraph
@@ -181,6 +167,8 @@ jobs:
         ./dgraph-instance.schema.sh
         ./dgraph-instance.insert.sh
       shell: bash
+
+    - run: echo "${{ hashFiles('**/requirements.txt') }}"
 
     - name: Scala Test
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - run: |
+          find
+
+      - run: |
+          find . -name requirements.txt
+
+      - name: Cache Pip packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-build-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-build-
+
       - name: Parametrize Extraction
         id: params-extract
         run: |
@@ -118,12 +132,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-
-    - run: |
-        find
-
-    - run: |
-        find . -name requirements.txt
 
     - name: Fetch Binaries Artifact
       uses: actions/download-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,14 +158,16 @@ jobs:
       env:
         DGRAPH_TEST_CLUSTER_VERSION: ${{ matrix.dgraph-version }}
       run: |
-        echo "::set-output name=docker::$(./dgraph-instance.background.sh)"
+        cp -v dgraph-instance.*.sh /tmp/
+        echo "::set-output name=docker::$(/tmp/dgraph-instance.background.sh)"
         sleep 10
         if [[ "${{ matrix.dgraph-version }}" != "20.03."* ]]
         then
-          ./dgraph-instance.drop-all.sh
+          /tmp/dgraph-instance.drop-all.sh
         fi
-        ./dgraph-instance.schema.sh
-        ./dgraph-instance.insert.sh
+        /tmp/dgraph-instance.schema.sh
+        /tmp/dgraph-instance.insert.sh
+        ls -lah /tmp/
       shell: bash
 
     - run: echo "${{ hashFiles('**/requirements.txt') }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,16 +141,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-build-${{ hashFiles("**/requirements.txt") }}
-        restore-keys: |
-          ${{ runner.os }}-pip-build-
-
-    - name: Cache Pip packages
-      if: always()
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-build-${{ hashFiles("python/requirements.txt") }}
+        key: ${{ runner.os }}-pip-build-${{ hashFiles('python/requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-build-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,12 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
+    - run: |
+        find
+
+    - run: |
+        find . -name requirements.txt
+
     - name: Fetch Binaries Artifact
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,14 +277,15 @@ jobs:
       env:
         DGRAPH_TEST_CLUSTER_VERSION: ${{ matrix.dgraph-version }}
       run: |
-        echo "::set-output name=docker::$(./dgraph-instance.background.sh)"
+        cp -v dgraph-instance.*.sh /tmp/
+        echo "::set-output name=docker::$(/tmp/dgraph-instance.background.sh)"
         sleep 10
         if [[ "${{ matrix.dgraph-version }}" != "20.03."* ]]
         then
-          ./dgraph-instance.drop-all.sh
+          /tmp/dgraph-instance.drop-all.sh
         fi
-        ./dgraph-instance.schema.sh
-        ./dgraph-instance.insert.sh
+        /tmp/dgraph-instance.schema.sh
+        /tmp/dgraph-instance.insert.sh
       shell: bash
 
     - name: Integration Tests
@@ -296,12 +297,6 @@ jobs:
       # There is no Spark 3.2 release of graphframes yet, so we use Spark 3.0 for now
       run: |
         ${SPARK_HOME}/bin/spark-submit --packages uk.co.gresearch.spark:${ARTIFACT_ID}:${VERSION},graphframes:graphframes:${{ steps.params.outputs.graphframes-version }}-spark3.0-s_2.12 --class uk.co.gresearch.spark.dgraph.connector.example.ExampleApp examples/scala/target/spark-dgraph-connector-examples_*.jar
-      shell: bash
-
-    - name: Stop Dgraph cluster
-      if: always() && steps.dgraph.outcome == 'success'
-      run: |
-        docker stop ${{ steps.dgraph.outputs.docker }}
       shell: bash
 
   delete_binaries:

--- a/README.md
+++ b/README.md
@@ -689,3 +689,4 @@ The Python code can be tested with `pytest`:
 ```shell script
 PYTHONPATH="python:python/test" python -m pytest python/test
 ```
+

--- a/README.md
+++ b/README.md
@@ -689,4 +689,3 @@ The Python code can be tested with `pytest`:
 ```shell script
 PYTHONPATH="python:python/test" python -m pytest python/test
 ```
-


### PR DESCRIPTION
Starting the dgraph cluster creates a directory in CWD that is own and only readable by root. This breaks `hashFiles`, if that directory is tried to be traversed. This makes that directory appear in /tmp, which is outside CWD.