### PR TITLE
Make sources report their ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [UNRELEASED] - YYYY-MM-DD
 
+### Added
+- All sources report their partitioning to Spark so that Spark can exploit that partitioning.
+
 ### Changed
 - Node source in wide mode does not allow for any predicate partitioning.
 - SingletonPartitioner now provides all features (filter and projection pushdown)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [UNRELEASED] - YYYY-MM-DD
+
+### Changed
+- Node source in wide mode does not allow for any predicate partitioning.
+
 ## [0.8.0] - 2022-01-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Node source in wide mode does not allow for any predicate partitioning.
+- SingletonPartitioner now provides all features (filter and projection pushdown)
+  of predicate partitioning, but as a single partition.
 
 ## [0.8.0] - 2022-01-19
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
     <scala.compat.version>2.12</scala.compat.version>
     <scala.version>${scala.compat.version}.10</scala.version>
     <!-- spark.compat.version must be reflected in project version -->
-    <spark.compat.version>3.2</spark.compat.version>
-    <spark.version>${spark.compat.version}.0</spark.version>
+    <spark.compat.version>3.3</spark.compat.version>
+    <spark.version>${spark.compat.version}.0-SNAPSHOT</spark.version>
   </properties>
 
   <!-- required to resolve GraphFrames dependency -->
@@ -94,12 +94,6 @@
       <artifactId>dgraph4j</artifactId>
       <version>21.12.0</version>
       <exclusions>
-        <!-- Spark comes with a specific netty version, we want to compile against that version -->
-        <!-- This fixes: java.lang.ClassCastException: class io.netty.channel.epoll.EpollSocketChannel -->
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-codec-http2</artifactId>
-        </exclusion>
         <!-- Spark comes with a specific netty version, we want to compile against that version -->
         <!-- This fixes: java.lang.ClassCastException: class io.netty.channel.epoll.EpollSocketChannel -->
         <exclusion>

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/TripleScan.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/TripleScan.scala
@@ -16,11 +16,11 @@
 
 package uk.co.gresearch.spark.dgraph.connector
 
+import org.apache.spark.sql.connector.read._
 import org.apache.spark.sql.connector.read.partitioning.{ClusteredDistribution, Distribution, Partitioning}
-import org.apache.spark.sql.connector.read.{Batch, InputPartition, PartitionReaderFactory, Scan, SupportsReportPartitioning}
 import org.apache.spark.sql.types.StructType
 import uk.co.gresearch.spark.dgraph.connector.model.GraphTableModel
-import uk.co.gresearch.spark.dgraph.connector.partitioner.{Partitioner, PredicatePartitioner}
+import uk.co.gresearch.spark.dgraph.connector.partitioner.Partitioner
 
 case class TripleScan(partitioner: Partitioner, model: GraphTableModel)
   extends Scan with SupportsReportPartitioning
@@ -30,13 +30,15 @@ case class TripleScan(partitioner: Partitioner, model: GraphTableModel)
 
   override def toBatch: Batch = this
 
-  override def planInputPartitions(): Array[InputPartition] = partitioner.getPartitions.toArray
+  private lazy val partitions: Array[InputPartition] = partitioner.getPartitions.toArray
+
+  override def planInputPartitions(): Array[InputPartition] = partitions
 
   override def createReaderFactory(): PartitionReaderFactory =
     TriplePartitionReaderFactory(model.withMetrics(AccumulatorPartitionMetrics()))
 
   override def outputPartitioning(): Partitioning = new Partitioning {
-    def numPartitions: Int = planInputPartitions().length
+    def numPartitions: Int = partitions.length
 
     def satisfy(distribution: Distribution): Boolean = distribution match {
       case c: ClusteredDistribution =>

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/package.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/package.scala
@@ -182,7 +182,8 @@ package object connector {
   val AlphaPartitionerOption: String = "alpha"
   val PredicatePartitionerOption: String = "predicate"
   val UidRangePartitionerOption: String = "uid-range"
-  val PartitionerDefault: String = s"$PredicatePartitionerOption+$UidRangePartitionerOption"
+  val PredicateAndUidRangePartitionerOption: String = s"$PredicatePartitionerOption+$UidRangePartitionerOption"
+  val PartitionerDefault: String = PredicateAndUidRangePartitionerOption
 
   val AlphaPartitionerPartitionsOption: String = "dgraph.partitioner.alpha.partitionsPerAlpha"
   val AlphaPartitionerPartitionsDefault: Int = 1

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/AlphaPartitioner.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/AlphaPartitioner.scala
@@ -16,13 +16,15 @@
 
 package uk.co.gresearch.spark.dgraph.connector.partitioner
 
-import uk.co.gresearch.spark.dgraph.connector.{ClusterState, Partition, Schema}
+import uk.co.gresearch.spark.dgraph.connector.{AlphaPartitionerOption, ClusterState, Partition, Schema}
 
 case class AlphaPartitioner(schema: Schema, clusterState: ClusterState, partitionsPerAlpha: Int)
   extends Partitioner with ClusterStateHelper {
 
   if (partitionsPerAlpha <= 0)
     throw new IllegalArgumentException(s"partitionsPerAlpha must be larger than zero: $partitionsPerAlpha")
+
+  override def configOption: String = AlphaPartitionerOption
 
   override def getPartitions: Seq[Partition] = {
     PredicatePartitioner.getPartitions(

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/AlphaPartitioner.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/AlphaPartitioner.scala
@@ -34,4 +34,6 @@ case class AlphaPartitioner(schema: Schema, clusterState: ClusterState, partitio
 
   override def getPartitionColumns: Option[Seq[String]] = Some(Seq("predicate"))
 
+  override def getOrderColumns: Option[Seq[String]] = None
+
 }

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/AlphaPartitioner.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/AlphaPartitioner.scala
@@ -30,4 +30,6 @@ case class AlphaPartitioner(schema: Schema, clusterState: ClusterState, partitio
     )
   }
 
+  override def getPartitionColumns: Option[Seq[String]] = Some(Seq("predicate"))
+
 }

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/ConfigPartitionerOption.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/ConfigPartitionerOption.scala
@@ -50,7 +50,7 @@ class ConfigPartitionerOption extends PartitionerProviderOption
         val estimator = getEstimatorOption(UidRangePartitionerEstimatorOption, options, UidRangePartitionerEstimatorDefault, clusterState)
         val targets = getAllClusterTargets(clusterState)
         val singleton = SingletonPartitioner(targets, schema)
-        UidRangePartitioner(singleton, uidsPerPartition, estimator)
+        UidRangePartitioner(singleton, uidsPerPartition, estimator, innerPartitionerIsDefault = true)
       case option if option.endsWith(s"+${UidRangePartitionerOption}") =>
         val name = option.substring(0, option.indexOf('+'))
         val partitioner = getPartitioner(name, schema, clusterState, transaction, options)

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/DefaultPartitionerOption.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/DefaultPartitionerOption.scala
@@ -16,15 +16,6 @@
 
 package uk.co.gresearch.spark.dgraph.connector.partitioner
 
-import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import uk.co.gresearch.spark.dgraph.connector._
 
-class DefaultPartitionerOption extends ConfigPartitionerOption {
-
-  override def getPartitioner(schema: Schema,
-                              clusterState: ClusterState,
-                              transaction: Option[Transaction],
-                              options: CaseInsensitiveStringMap): Option[Partitioner] =
-    Some(getPartitioner(PartitionerDefault, schema, clusterState, transaction, options))
-
-}
+class DefaultPartitionerOption extends PartitionerOption(PartitionerDefault)

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/GroupPartitioner.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/GroupPartitioner.scala
@@ -20,6 +20,7 @@ import uk.co.gresearch.spark.dgraph.connector.{ClusterState, Partition, Schema}
 
 case class GroupPartitioner(schema: Schema, clusterState: ClusterState)
   extends Partitioner with ClusterStateHelper {
+
   override def getPartitions: Seq[Partition] =
     clusterState.groupMembers.map { case (group, alphas) =>
       (group, alphas, getGroupPredicates(clusterState, group, schema))
@@ -27,4 +28,7 @@ case class GroupPartitioner(schema: Schema, clusterState: ClusterState)
       val langs = predicates.filter(_.isLang).map(_.predicateName)
       Partition(alphas.toSeq).has(predicates).langs(langs)
     }.toSeq
+
+  override def getPartitionColumns: Option[Seq[String]] = Some(Seq("predicate"))
+
 }

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/GroupPartitioner.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/GroupPartitioner.scala
@@ -33,4 +33,6 @@ case class GroupPartitioner(schema: Schema, clusterState: ClusterState)
 
   override def getPartitionColumns: Option[Seq[String]] = Some(Seq("predicate"))
 
+  override def getOrderColumns: Option[Seq[String]] = None
+
 }

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/GroupPartitioner.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/GroupPartitioner.scala
@@ -16,10 +16,12 @@
 
 package uk.co.gresearch.spark.dgraph.connector.partitioner
 
-import uk.co.gresearch.spark.dgraph.connector.{ClusterState, Partition, Schema}
+import uk.co.gresearch.spark.dgraph.connector.{ClusterState, GroupPartitionerOption, Partition, Schema}
 
 case class GroupPartitioner(schema: Schema, clusterState: ClusterState)
   extends Partitioner with ClusterStateHelper {
+
+  override def configOption: String = GroupPartitionerOption
 
   override def getPartitions: Seq[Partition] =
     clusterState.groupMembers.map { case (group, alphas) =>

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/Partitioner.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/Partitioner.scala
@@ -34,9 +34,13 @@ trait Partitioner {
 
   /**
    * Get the column names that represent the partitioning.
-   * @return
    */
   def getPartitionColumns: Option[Seq[String]]
+
+  /**
+   * Get the column names that partitions are ordered by.
+   */
+  def getOrderColumns: Option[Seq[String]]
 
   /**
    * Indicates whether this partitioner supports all given filters.

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/Partitioner.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/Partitioner.scala
@@ -17,7 +17,7 @@
 package uk.co.gresearch.spark.dgraph.connector.partitioner
 
 import uk.co.gresearch.spark.dgraph.connector
-import uk.co.gresearch.spark.dgraph.connector.{Filters, Partition, PartitionMetrics, Predicate}
+import uk.co.gresearch.spark.dgraph.connector.{Filters, Partition, Predicate}
 
 trait Partitioner {
 
@@ -25,6 +25,12 @@ trait Partitioner {
    * Gets the partitions.
    */
   def getPartitions: Seq[Partition]
+
+  /**
+   * Get the column names that represent the partitioning.
+   * @return
+   */
+  def getPartitionColumns: Option[Seq[String]]
 
   /**
    * Indicates whether this partitioner supports all given filters.

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/Partitioner.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/Partitioner.scala
@@ -22,6 +22,12 @@ import uk.co.gresearch.spark.dgraph.connector.{Filters, Partition, Predicate}
 trait Partitioner {
 
   /**
+   * The option string used for config "dgraph.partitioner" (PartitionerOption) to reference this partitioner.
+   * @return config option string
+   */
+  def configOption: String
+
+  /**
    * Gets the partitions.
    */
   def getPartitions: Seq[Partition]

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/PartitionerOption.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/PartitionerOption.scala
@@ -1,0 +1,14 @@
+package uk.co.gresearch.spark.dgraph.connector.partitioner
+
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import uk.co.gresearch.spark.dgraph.connector.{ClusterState, Schema, Transaction}
+
+class PartitionerOption(partitionerOption: String) extends ConfigPartitionerOption {
+
+  override def getPartitioner(schema: Schema,
+                              clusterState: ClusterState,
+                              transaction: Option[Transaction],
+                              options: CaseInsensitiveStringMap): Option[Partitioner] =
+    Some(getPartitioner(partitionerOption, schema, clusterState, transaction, options))
+
+}

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/PartitionerProvider.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/PartitionerProvider.scala
@@ -17,22 +17,24 @@
 package uk.co.gresearch.spark.dgraph.connector.partitioner
 
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
-import uk.co.gresearch.spark.dgraph.connector.{ClusterState, Schema, Transaction}
+import uk.co.gresearch.spark.dgraph.connector.partitioner.PartitionerProvider.{configPartitionProvider, defaultPartitionProvider}
+import uk.co.gresearch.spark.dgraph.connector.{ClusterState, Schema, SingletonPartitionerOption, Transaction}
 
 trait PartitionerProvider {
-
-  val partitionerOptions = Seq(
-    new ConfigPartitionerOption(),
-    new DefaultPartitionerOption()
-  )
 
   def getPartitioner(schema: Schema,
                      clusterState: ClusterState,
                      transaction: Option[Transaction],
-                     options: CaseInsensitiveStringMap): Partitioner =
-    partitionerOptions
+                     options: CaseInsensitiveStringMap,
+                     defaultPartitionProvider: PartitionerProviderOption = defaultPartitionProvider): Partitioner =
+    Seq(configPartitionProvider, defaultPartitionProvider)
       .flatMap(_.getPartitioner(schema, clusterState, transaction, options))
       .headOption
       .getOrElse(throw new RuntimeException("Could not find any suitable partitioner"))
 
+}
+
+object PartitionerProvider {
+  val defaultPartitionProvider: PartitionerProviderOption = new DefaultPartitionerOption()
+  val configPartitionProvider: PartitionerProviderOption = new ConfigPartitionerOption()
 }

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/PartitionerProvider.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/PartitionerProvider.scala
@@ -18,7 +18,7 @@ package uk.co.gresearch.spark.dgraph.connector.partitioner
 
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import uk.co.gresearch.spark.dgraph.connector.partitioner.PartitionerProvider.{configPartitionProvider, defaultPartitionProvider}
-import uk.co.gresearch.spark.dgraph.connector.{ClusterState, Schema, SingletonPartitionerOption, Transaction}
+import uk.co.gresearch.spark.dgraph.connector.{ClusterState, Schema, Transaction}
 
 trait PartitionerProvider {
 

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/PredicatePartitioner.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/PredicatePartitioner.scala
@@ -72,6 +72,8 @@ case class PredicatePartitioner(schema: Schema,
     PredicatePartitioner.getPartitions(schema, cState, (_, predicates) => getPartitionsForPredicates(predicates), simplifiedFilters, projection)
   }
 
+  override def getPartitionColumns: Option[Seq[String]] = Some(Seq("predicate"))
+
   /**
    * Replaces ObjectTypeIsIn filter in required and optional filters
    * using replaceObjectTypeIsInFilter(filters: Seq[Filter]).

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/PredicatePartitioner.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/PredicatePartitioner.scala
@@ -16,12 +16,11 @@
 
 package uk.co.gresearch.spark.dgraph.connector.partitioner
 
-import java.math.BigInteger
-import java.security.MessageDigest
-
 import uk.co.gresearch.spark.dgraph.connector
 import uk.co.gresearch.spark.dgraph.connector._
 
+import java.math.BigInteger
+import java.security.MessageDigest
 import scala.language.implicitConversions
 
 case class PredicatePartitioner(schema: Schema,
@@ -33,6 +32,8 @@ case class PredicatePartitioner(schema: Schema,
 
   if (predicatesPerPartition <= 0)
     throw new IllegalArgumentException(s"predicatesPerPartition must be larger than zero: $predicatesPerPartition")
+
+  override def configOption: String = PredicatePartitionerOption
 
   def getPartitionsForPredicates(predicates: Set[_]): Int =
     if (predicates.isEmpty) 1 else 1 + (predicates.size - 1) / predicatesPerPartition

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/SingletonPartitioner.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/SingletonPartitioner.scala
@@ -25,4 +25,6 @@ case class SingletonPartitioner(targets: Seq[Target], schema: Schema) extends Pa
     Seq(Partition(targets).has(schema.predicates).langs(langs))
   }
 
+  override def getPartitionColumns: Option[Seq[String]] = None
+
 }

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/SingletonPartitioner.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/SingletonPartitioner.scala
@@ -16,17 +16,31 @@
 
 package uk.co.gresearch.spark.dgraph.connector.partitioner
 
-import uk.co.gresearch.spark.dgraph.connector.{Partition, Schema, SingletonPartitionerOption, Target}
+import uk.co.gresearch.spark.dgraph.connector.{ClusterState, EmptyFilters, Filters, Predicate, Schema, SingletonPartitionerOption}
 
-case class SingletonPartitioner(targets: Seq[Target], schema: Schema) extends Partitioner {
+/**
+ * This partitioner produces a single partition, but provides the features
+ * of the PredicatePartitioner (filtering and projection, though for a single partition).
+ */
+class SingletonPartitioner(override val schema: Schema,
+                           override val clusterState: ClusterState,
+                           override val filters: Filters = EmptyFilters,
+                           override val projection: Option[Seq[Predicate]] = None)
+  extends PredicatePartitioner(schema, clusterState, Int.MaxValue, filters, projection) {
 
   override def configOption: String = SingletonPartitionerOption
 
-  override def getPartitions: Seq[Partition] = {
-    val langs = schema.predicates.filter(_.isLang).map(_.predicateName)
-    Seq(Partition(targets).has(schema.predicates).langs(langs))
-  }
-
   override def getPartitionColumns: Option[Seq[String]] = None
 
+  override def withFilters(filters: Filters): Partitioner =
+    new SingletonPartitioner(schema, clusterState, filters, projection)
+
+  override def withProjection(projection: Seq[Predicate]): Partitioner =
+    new SingletonPartitioner(schema, clusterState, filters, Some(projection))
+
+}
+
+object SingletonPartitioner {
+  def apply(schema: Schema, clusterState: ClusterState): SingletonPartitioner =
+    new SingletonPartitioner(schema, clusterState)
 }

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/SingletonPartitioner.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/SingletonPartitioner.scala
@@ -16,9 +16,11 @@
 
 package uk.co.gresearch.spark.dgraph.connector.partitioner
 
-import uk.co.gresearch.spark.dgraph.connector.{Partition, Schema, Target}
+import uk.co.gresearch.spark.dgraph.connector.{Partition, Schema, SingletonPartitionerOption, Target}
 
 case class SingletonPartitioner(targets: Seq[Target], schema: Schema) extends Partitioner {
+
+  override def configOption: String = SingletonPartitionerOption
 
   override def getPartitions: Seq[Partition] = {
     val langs = schema.predicates.filter(_.isLang).map(_.predicateName)

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/UidRangePartitioner.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/UidRangePartitioner.scala
@@ -19,7 +19,8 @@ package uk.co.gresearch.spark.dgraph.connector.partitioner
 import uk.co.gresearch.spark.dgraph.connector
 import uk.co.gresearch.spark.dgraph.connector.{Filter, Filters, Partition, Uid, UidRange}
 
-case class UidRangePartitioner(partitioner: Partitioner, uidsPerPartition: Int, uidCardinalityEstimator: UidCardinalityEstimator) extends Partitioner {
+case class UidRangePartitioner(partitioner: Partitioner, uidsPerPartition: Int, uidCardinalityEstimator: UidCardinalityEstimator)
+  extends Partitioner {
 
   if (partitioner == null)
     throw new IllegalArgumentException("partitioner must not be null")
@@ -65,5 +66,9 @@ case class UidRangePartitioner(partitioner: Partitioner, uidsPerPartition: Int, 
       }
     }
   }
+
+  override def getPartitionColumns: Option[Seq[String]] =
+    partitioner.getPartitionColumns.map(_ :+ "subject")
+      .orElse(Some(Seq("subject")))
 
 }

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/UidRangePartitioner.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/UidRangePartitioner.scala
@@ -80,4 +80,8 @@ case class UidRangePartitioner(partitioner: Partitioner,
     partitioner.getPartitionColumns.map(_ :+ "subject")
       .orElse(Some(Seq("subject")))
 
+  // whatever order the inner partitioner has, this one additionally orders partitions by subject
+  override def getOrderColumns: Option[Seq[String]] =
+    partitioner.getOrderColumns.map(columns => columns :+ "subject")
+
 }

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/UidRangePartitioner.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/UidRangePartitioner.scala
@@ -17,9 +17,12 @@
 package uk.co.gresearch.spark.dgraph.connector.partitioner
 
 import uk.co.gresearch.spark.dgraph.connector
-import uk.co.gresearch.spark.dgraph.connector.{Filter, Filters, Partition, Uid, UidRange}
+import uk.co.gresearch.spark.dgraph.connector.{Filter, Filters, Partition, Uid, UidRange, UidRangePartitionerOption}
 
-case class UidRangePartitioner(partitioner: Partitioner, uidsPerPartition: Int, uidCardinalityEstimator: UidCardinalityEstimator)
+case class UidRangePartitioner(partitioner: Partitioner,
+                               uidsPerPartition: Int,
+                               uidCardinalityEstimator: UidCardinalityEstimator,
+                               innerPartitionerIsDefault: Boolean = false)
   extends Partitioner {
 
   if (partitioner == null)
@@ -33,6 +36,12 @@ case class UidRangePartitioner(partitioner: Partitioner, uidsPerPartition: Int, 
   if (partitions.exists(_.uidRange.isDefined))
     throw new IllegalArgumentException(s"UidRangePartitioner cannot be combined with " +
       s"another uid partitioner: ${partitioner.getClass.getSimpleName}")
+
+  override def configOption: String = if (innerPartitionerIsDefault) {
+    UidRangePartitionerOption
+  } else {
+    s"${partitioner.configOption}+$UidRangePartitionerOption"
+  }
 
   override def supportsFilters(filters: Set[Filter]): Boolean = partitioner.supportsFilters(filters)
 

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/FilterPushdownTestHelper.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/FilterPushdownTestHelper.scala
@@ -38,7 +38,7 @@ trait FilterPushdownTestHelper extends Assertions {
                                 condition: Column,
                                 expectedFilters: Set[Filter],
                                 expectedUnpushed: Seq[Expression] = Seq.empty,
-                                expectedDs: Set[T] = Set.empty): Unit = {
+                                expecteds: Set[T] = Set.empty): Unit = {
     val conditionedDs = ds.where(condition)
     val plan = conditionedDs.queryExecution.optimizedPlan
     val relationNode = plan match {
@@ -62,8 +62,8 @@ trait FilterPushdownTestHelper extends Assertions {
     assert(partitioner.filters === expectedFilters)
 
     val actual = conditionedDs.collect()
-    assert(actual.toSet === expectedDs)
-    assert(actual.length === expectedDs.size)
+    assert(actual.toSet === expecteds)
+    assert(actual.length === expecteds.size)
   }
 
   def getFilterNodes(node: Expression): Seq[Expression] = node match {

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestAlphaPartitioner.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestAlphaPartitioner.scala
@@ -83,6 +83,11 @@ class TestAlphaPartitioner extends AnyFunSpec {
       assertThrows[IllegalArgumentException]{ AlphaPartitioner(schema, clusterState, 0) }
     }
 
+    it("should partition by predicate column") {
+      val partitioner = AlphaPartitioner(schema, clusterState, 10)
+      assert(partitioner.getPartitionColumns === Some(Seq("predicate")))
+    }
+
     it("should partition reduced schema") {
       // take the odd predicates from schema only, index is 0 based
       val reducedSchema = Schema(schema.predicates.toSeq.sortBy(_.predicateName).zipWithIndex.filter(_._2 % 2 == 0).map(_._1).toSet)

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestGroupPartitioner.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestGroupPartitioner.scala
@@ -52,6 +52,11 @@ class TestGroupPartitioner extends AnyFunSpec {
       ))
     }
 
+    it("should partition by predicate column") {
+      val partitioner = GroupPartitioner(schema, clusterState)
+      assert(partitioner.getPartitionColumns === Some(Seq("predicate")))
+    }
+
     it("should provide lang directives") {
       val langPreds = Set("pred3", "pred4")
       val langSchema = Schema(schema.predicates.map(p => if (langPreds.contains(p.predicateName)) p.copy(isLang = true) else p))

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestPartitionerProvider.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestPartitionerProvider.scala
@@ -52,7 +52,7 @@ class TestPartitionerProvider extends AnyFunSpec {
       ("alpha", alpha),
       ("predicate", pred),
 
-      ("uid-range", uidRange),
+      ("uid-range", uidRange.copy(innerPartitionerIsDefault = true)),
       ("singleton+uid-range", uidRange),
       ("group+uid-range", uidRange.copy(partitioner = group)),
       ("alpha+uid-range", uidRange.copy(partitioner = alpha)),
@@ -64,6 +64,7 @@ class TestPartitionerProvider extends AnyFunSpec {
         val options = new CaseInsensitiveStringMap(Map(PartitionerOption -> partOption).asJava)
         val partitioner = provider.getPartitioner(schema, state, transaction, options)
         assert(partitioner === expected)
+        assert(partitioner.configOption === partOption)
       }
 
     }

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestPartitionerProvider.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestPartitionerProvider.scala
@@ -40,7 +40,7 @@ class TestPartitionerProvider extends AnyFunSpec {
 
   describe("PartitionerProvider") {
 
-    val singleton = SingletonPartitioner(target, schema)
+    val singleton = SingletonPartitioner(schema, state)
     val group = GroupPartitioner(schema, state)
     val alpha = AlphaPartitioner(schema, state, AlphaPartitionerPartitionsDefault)
     val pred = PredicatePartitioner(schema, state, PredicatePartitionerPredicatesDefault)
@@ -133,7 +133,7 @@ class TestPartitionerProvider extends AnyFunSpec {
         UidRangePartitionerEstimatorOption -> MaxLeaseIdEstimatorOption,
       ).asJava)
       val partitioner = provider.getPartitioner(schema, state, transaction, options)
-      assert(partitioner === uidRange.copy(uidsPerPartition = 2, uidCardinalityEstimator = maxLeaseEstimator))
+      assert(partitioner === uidRange.copy(uidsPerPartition = 2, uidCardinalityEstimator = maxLeaseEstimator, innerPartitionerIsDefault = true))
     }
 
     it(s"should provide alpha uid-range partitioner with non-default values via option") {

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestPredicatePartitioner.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestPredicatePartitioner.scala
@@ -138,6 +138,11 @@ class TestPredicatePartitioner extends AnyFunSpec {
       }
     }
 
+    it("should partition by predicate column") {
+      val partitioner = PredicatePartitioner(schema, clusterState, 2)
+      assert(partitioner.getPartitionColumns === Some(Seq("predicate")))
+    }
+
     it("should partition reduced schema") {
       // take the odd predicates from schema only, index is 0 based
       val reducedSchema = Schema(schema.predicates.toSeq.sortBy(_.predicateName).zipWithIndex.filter(_._2 % 2 == 0).map(_._1).toSet)

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestSingletonPartitioner.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestSingletonPartitioner.scala
@@ -27,8 +27,6 @@ class TestSingletonPartitioner extends AnyFunSpec {
 
     val targets = Seq(Target("host1:9080"), Target("host2:9080"))
     val predicates = Set(Predicate("pred", "type", "type"))
-    val schema = Schema(predicates)
-    val state = getState(predicates)
 
     def getState(predicates: Set[Predicate]): ClusterState = ClusterState(
       Map("1" -> targets.toSet),
@@ -36,6 +34,9 @@ class TestSingletonPartitioner extends AnyFunSpec {
       10000,
       UUID.randomUUID()
     )
+
+    val schema = Schema(predicates)
+    val state = getState(predicates)
 
     it("should partition") {
       val partitioner = SingletonPartitioner(schema, state)

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestSingletonPartitioner.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestSingletonPartitioner.scala
@@ -35,6 +35,13 @@ class TestSingletonPartitioner extends AnyFunSpec {
       assert(partitions.toSet === Set(Partition(targets).has(predicates)))
     }
 
+    it("should not partition by any column") {
+      val predicates = Set(Predicate("pred", "type", "type"))
+      val schema = Schema(predicates)
+      val partitioner = SingletonPartitioner(targets, schema)
+      assert(partitioner.getPartitionColumns === None)
+    }
+
     it("should provide lang directives") {
       val predicates = Set(Predicate("pred1", "type1", "type1"), Predicate("pred2", "type2", "type2", isLang = true))
       val schema = Schema(predicates)

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestSingletonPartitioner.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestSingletonPartitioner.scala
@@ -19,37 +19,47 @@ package uk.co.gresearch.spark.dgraph.connector.partitioner
 import org.scalatest.funspec.AnyFunSpec
 import uk.co.gresearch.spark.dgraph.connector._
 
+import java.util.UUID
+
 class TestSingletonPartitioner extends AnyFunSpec {
 
   describe("SingletonPartitioner") {
 
     val targets = Seq(Target("host1:9080"), Target("host2:9080"))
+    val predicates = Set(Predicate("pred", "type", "type"))
+    val schema = Schema(predicates)
+    val state = getState(predicates)
+
+    def getState(predicates: Set[Predicate]): ClusterState = ClusterState(
+      Map("1" -> targets.toSet),
+      Map("1" -> predicates.map(_.predicateName)),
+      10000,
+      UUID.randomUUID()
+    )
 
     it("should partition") {
-      val predicates = Set(Predicate("pred", "type", "type"))
-      val schema = Schema(predicates)
-      val partitioner = SingletonPartitioner(targets, schema)
+      val partitioner = SingletonPartitioner(schema, state)
       val partitions = partitioner.getPartitions
 
       assert(partitions.length === 1)
-      assert(partitions.toSet === Set(Partition(targets).has(predicates)))
+      assert(partitions.toSet === Set(Partition(targets).has(predicates).getAll))
     }
 
     it("should not partition by any column") {
-      val predicates = Set(Predicate("pred", "type", "type"))
-      val schema = Schema(predicates)
-      val partitioner = SingletonPartitioner(targets, schema)
+      val partitioner = SingletonPartitioner(schema, state)
       assert(partitioner.getPartitionColumns === None)
     }
 
     it("should provide lang directives") {
       val predicates = Set(Predicate("pred1", "type1", "type1"), Predicate("pred2", "type2", "type2", isLang = true))
       val schema = Schema(predicates)
-      val partitioner = SingletonPartitioner(targets, schema)
+      val state = getState(predicates)
+
+      val partitioner = SingletonPartitioner(schema, state)
       val partitions = partitioner.getPartitions
 
       assert(partitions.length === 1)
-      assert(partitions.toSet === Set(Partition(targets).has(predicates).langs(Set("pred2"))))
+      assert(partitions.toSet === Set(Partition(targets).has(predicates).getAll.langs(Set("pred2"))))
     }
 
   }

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestUidRangePartitioner.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestUidRangePartitioner.scala
@@ -56,6 +56,17 @@ class TestUidRangePartitioner extends AnyFunSpec {
     val testSizes = Seq(2000, 5000)
 
     testPartitioners.foreach { case (partitioner, label) =>
+
+      it(s"should add subject partition column to $label partitioner") {
+        val uidPartitioner = UidRangePartitioner(partitioner, 10, UidCardinalityEstimator.forMaxLeaseId(clusterState.maxLeaseId))
+
+        assert(uidPartitioner.getPartitionColumns.isDefined)
+        if (partitioner.getPartitionColumns.isDefined)
+          assert(uidPartitioner.getPartitionColumns.get === partitioner.getPartitionColumns.get :+ "subject")
+        else
+          assert(uidPartitioner.getPartitionColumns === Some(Seq("subject")))
+      }
+
       testSizes.foreach { size =>
 
         it(s"should decorate $label partitioner with ${size} uids per partition") {

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestUidRangePartitioner.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestUidRangePartitioner.scala
@@ -40,7 +40,7 @@ class TestUidRangePartitioner extends AnyFunSpec {
       UUID.randomUUID()
     )
 
-    val singleton = SingletonPartitioner(Seq(Target("host1:9080"), Target("host2:9080"), Target("host3:9080")), schema)
+    val singleton = SingletonPartitioner(schema, clusterState)
     val group = GroupPartitioner(schema, clusterState)
     val alpha = AlphaPartitioner(schema, clusterState, 1)
     val pred = PredicatePartitioner(schema, clusterState, 1)

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/ShuffleExchangeTests.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/ShuffleExchangeTests.scala
@@ -21,7 +21,7 @@ trait ShuffleExchangeTests {
     val label = if (shuffleExpected) "shuffle" else "reuse partitioning"
     tests.foreach {
       case (test, op, expected) =>
-        it(f"should $label for $test") {
+        it(s"should $label for $test") {
           val data = op(df())
           val plan = data.queryExecution.executedPlan match {
             case p: AdaptiveSparkPlanExec => p.executedPlan

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/ShuffleExchangeTests.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/ShuffleExchangeTests.scala
@@ -6,7 +6,6 @@ import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.{DataFrame, Row}
 import org.scalatest.funspec.AnyFunSpec
-import uk.co.gresearch.spark.dgraph.connector.sources.TestTriplesSource.removeDgraphTriples
 
 trait ShuffleExchangeTests {
   this: AnyFunSpec =>
@@ -23,7 +22,7 @@ trait ShuffleExchangeTests {
     tests.foreach {
       case (test, op, expected) =>
         it(f"should $label for $test") {
-          val data = op(removeDgraphTriples(df()))
+          val data = op(df())
           val plan = data.queryExecution.executedPlan match {
             case p: AdaptiveSparkPlanExec => p.executedPlan
             case p => p

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestEdgeSource.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestEdgeSource.scala
@@ -328,7 +328,7 @@ class TestEdgeSource extends AnyFunSpec with ShuffleExchangeTests
       val withoutPartitioning = () =>
         reader
           .options(Map(
-            PartitionerOption -> s"$UidRangePartitionerOption",
+            PartitionerOption -> UidRangePartitionerOption,
             UidRangePartitionerUidsPerPartOption -> "2",
             MaxLeaseIdEstimatorIdOption -> dgraph.highestUid.toString
           ))
@@ -374,7 +374,7 @@ class TestEdgeSource extends AnyFunSpec with ShuffleExchangeTests
       val withPartitioning = () =>
         reader
           .options(Map(
-            PartitionerOption -> s"$UidRangePartitionerOption",
+            PartitionerOption -> UidRangePartitionerOption,
             UidRangePartitionerUidsPerPartOption -> "2",
             MaxLeaseIdEstimatorIdOption -> dgraph.highestUid.toString
           ))
@@ -410,7 +410,7 @@ class TestEdgeSource extends AnyFunSpec with ShuffleExchangeTests
       val withPartitioning = () =>
         reader
           .options(Map(
-            PartitionerOption -> s"$PredicatePartitionerOption+$UidRangePartitionerOption",
+            PartitionerOption -> PredicateAndUidRangePartitionerOption,
             PredicatePartitionerPredicatesOption -> "1",
             UidRangePartitionerUidsPerPartOption -> "2",
             MaxLeaseIdEstimatorIdOption -> dgraph.highestUid.toString

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestEdgeSource.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestEdgeSource.scala
@@ -136,11 +136,14 @@ class TestEdgeSource extends AnyFunSpec with ShuffleExchangeTests
           case p: DataSourceRDDPartition => Some(p.inputPartition)
           case _ => None
         }
-      assert(partitions === Seq(Some(Partition(targets).has(Set(Predicate("director", "uid"), Predicate("starring", "uid"))))))
+      assert(partitions === Seq(
+        Some(Partition(targets).has(Set(Predicate("director", "uid"), Predicate("starring", "uid"))).getAll))
+      )
     }
 
     it("should load as a predicate partitions") {
       val target = dgraph.target
+      val targets = Seq(Target(target))
       val partitions =
         reader
           .option(PartitionerOption, PredicatePartitionerOption)
@@ -153,7 +156,7 @@ class TestEdgeSource extends AnyFunSpec with ShuffleExchangeTests
         }
 
       val expected = Set(
-        Some(Partition(Seq(Target(dgraph.target))).has(Set.empty, Set("director", "starring")).getAll)
+        Some(Partition(targets).has(Set.empty, Set("director", "starring")).getAll)
       )
 
       assert(partitions.toSet === expected)

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestEdgeSource.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestEdgeSource.scala
@@ -35,7 +35,7 @@ class TestEdgeSource extends AnyFunSpec with ShuffleExchangeTests
 
   import spark.implicits._
 
-  describe("EdgeDataSource") {
+  describe("EdgeSource") {
 
     lazy val expecteds = EdgesSourceExpecteds(dgraph)
     lazy val expectedRows = expecteds.getExpectedEdgeDf(spark).collect().toSet

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestEdgeSource.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestEdgeSource.scala
@@ -19,6 +19,8 @@ package uk.co.gresearch.spark.dgraph.connector.sources
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Expression, In, Literal}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceRDDPartition
+import org.apache.spark.sql.expressions.Window
+import org.apache.spark.sql.functions.{count, lit, row_number}
 import org.apache.spark.sql.types.LongType
 import org.scalatest.funspec.AnyFunSpec
 import uk.co.gresearch.spark.dgraph.connector._
@@ -26,7 +28,7 @@ import uk.co.gresearch.spark.dgraph.{DgraphCluster, DgraphTestCluster}
 
 import scala.reflect.runtime.universe._
 
-class TestEdgeSource extends AnyFunSpec
+class TestEdgeSource extends AnyFunSpec with ShuffleExchangeTests
   with ConnectorSparkTestSession with DgraphTestCluster
   with FilterPushdownTestHelper
   with ProjectionPushDownTestHelper {
@@ -36,11 +38,12 @@ class TestEdgeSource extends AnyFunSpec
   describe("EdgeDataSource") {
 
     lazy val expecteds = EdgesSourceExpecteds(dgraph)
-    lazy val expectedEdges = expecteds.getExpectedEdgeDf(spark).collect().toSet
+    lazy val expectedRows = expecteds.getExpectedEdgeDf(spark).collect().toSet
+    lazy val expectedEdges = expecteds.getExpectedEdges
 
     def doTestLoadEdges(load: () => DataFrame): Unit = {
       val edges = load().collect().toSet
-      assert(edges === expectedEdges)
+      assert(edges === expectedRows)
     }
 
     it("should load edges via path") {
@@ -183,6 +186,7 @@ class TestEdgeSource extends AnyFunSpec
           PredicatePartitionerPredicatesOption -> "2"
         ))
         .dgraph.edges(dgraph.target)
+        .as[Edge]
     lazy val edgesSinglePredicatePerPartition =
       spark
         .read
@@ -191,24 +195,25 @@ class TestEdgeSource extends AnyFunSpec
           PredicatePartitionerPredicatesOption -> "1"
         ))
         .dgraph.edges(dgraph.target)
+        .as[Edge]
 
     it("should push subject filters") {
       doTestFilterPushDown(
         $"subject" === dgraph.leia,
         Set(SubjectIsIn(Uid(dgraph.leia))),
-        expectedDf = expectedEdges.filter(_.getLong(0) == dgraph.leia)
+        expecteds = expectedEdges.filter(_.subject == dgraph.leia)
       )
 
       doTestFilterPushDown(
         $"subject".isin(dgraph.leia),
         Set(SubjectIsIn(Uid(dgraph.leia))),
-        expectedDf = expectedEdges.filter(_.getLong(0) == dgraph.leia)
+        expecteds = expectedEdges.filter(_.subject == dgraph.leia)
       )
 
       doTestFilterPushDown(
         $"subject".isin(dgraph.leia, dgraph.luke),
         Set(SubjectIsIn(Uid(dgraph.leia), Uid(dgraph.luke))),
-        expectedDf = expectedEdges.filter(r => Set(dgraph.leia, dgraph.luke).contains(r.getLong(0)))
+        expecteds = expectedEdges.filter(r => Set(dgraph.leia, dgraph.luke).contains(r.subject))
       )
     }
 
@@ -216,19 +221,19 @@ class TestEdgeSource extends AnyFunSpec
       doTestFilterPushDown(
         $"predicate" === "director",
         Set(IntersectPredicateNameIsIn("director")),
-        expectedDf = expectedEdges.filter(_.getString(1) == "director")
+        expecteds = expectedEdges.filter(_.predicate == "director")
       )
 
       doTestFilterPushDown(
         $"predicate".isin("director"),
         Set(IntersectPredicateNameIsIn("director")),
-        expectedDf = expectedEdges.filter(_.getString(1) == "director")
+        expecteds = expectedEdges.filter(_.predicate == "director")
       )
 
       doTestFilterPushDown(
         $"predicate".isin("director", "starring"),
         Set(IntersectPredicateNameIsIn("director", "starring")),
-        expectedDf = expectedEdges.filter(r => Set("director", "starring").contains(r.getString(1)))
+        expecteds = expectedEdges.filter(r => Set("director", "starring").contains(r.predicate))
       )
     }
 
@@ -239,13 +244,13 @@ class TestEdgeSource extends AnyFunSpec
         Set(ObjectValueIsIn(dgraph.leia), ObjectTypeIsIn("uid")),
         // With multiple predicates per partition, we cannot filter for object values
         Seq(EqualTo(AttributeReference("objectUid", LongType, nullable = true)(), Literal(dgraph.leia))),
-        expectedDs = expectedEdges.filter(_.getLong(2) == dgraph.leia)
+        expecteds = expectedEdges.filter(_.objectUid == dgraph.leia)
       )
       doTestFilterPushDownDf(
         edgesSinglePredicatePerPartition,
         $"objectUid" === dgraph.leia,
         Set(ObjectValueIsIn(dgraph.leia), ObjectTypeIsIn("uid")),
-        expectedDs = expectedEdges.filter(_.getLong(2) == dgraph.leia)
+        expecteds = expectedEdges.filter(_.objectUid == dgraph.leia)
       )
 
       doTestFilterPushDownDf(
@@ -254,13 +259,13 @@ class TestEdgeSource extends AnyFunSpec
         Set(ObjectValueIsIn(dgraph.leia), ObjectTypeIsIn("uid")),
         // With multiple predicates per partition, we cannot filter for object values
         Seq(EqualTo(AttributeReference("objectUid", LongType, nullable = true)(), Literal(dgraph.leia))),
-        expectedDs = expectedEdges.filter(_.getLong(2) == dgraph.leia)
+        expecteds = expectedEdges.filter(_.objectUid == dgraph.leia)
       )
       doTestFilterPushDownDf(
         edgesSinglePredicatePerPartition,
         $"objectUid".isin(dgraph.leia),
         Set(ObjectValueIsIn(dgraph.leia), ObjectTypeIsIn("uid")),
-        expectedDs = expectedEdges.filter(_.getLong(2) == dgraph.leia)
+        expecteds = expectedEdges.filter(_.objectUid == dgraph.leia)
       )
 
       doTestFilterPushDownDf(
@@ -269,43 +274,42 @@ class TestEdgeSource extends AnyFunSpec
         Set(ObjectValueIsIn(dgraph.leia, dgraph.lucas), ObjectTypeIsIn("uid")),
         // With multiple predicates per partition, we cannot filter for object values
         Seq(In(AttributeReference("objectUid", LongType, nullable = true)(), Seq(Literal(dgraph.leia), Literal(dgraph.lucas)))),
-        expectedDs = expectedEdges.filter(r => Set(dgraph.leia, dgraph.lucas).contains(r.getLong(2)))
+        expecteds = expectedEdges.filter(r => Set(dgraph.leia, dgraph.lucas).contains(r.objectUid))
       )
       doTestFilterPushDownDf(
         edgesSinglePredicatePerPartition,
         $"objectUid".isin(dgraph.leia, dgraph.lucas),
         Set(ObjectValueIsIn(dgraph.leia, dgraph.lucas), ObjectTypeIsIn("uid")),
-        expectedDs = expectedEdges.filter(r => Set(dgraph.leia, dgraph.lucas).contains(r.getLong(2)))
+        expecteds = expectedEdges.filter(r => Set(dgraph.leia, dgraph.lucas).contains(r.objectUid))
       )
     }
 
-    def doTestFilterPushDown(condition: Column, expectedFilters: Set[Filter], expectedUnpushed: Seq[Expression] = Seq.empty, expectedDf: Set[Row]): Unit = {
-      doTestFilterPushDownDf(edges, condition, expectedFilters, expectedUnpushed, expectedDf)
+    def doTestFilterPushDown(condition: Column, expectedFilters: Set[Filter], expectedUnpushed: Seq[Expression] = Seq.empty, expecteds: Set[Edge]): Unit = {
+      doTestFilterPushDownDf(edges, condition, expectedFilters, expectedUnpushed, expecteds)
     }
 
     it("should not push projection") {
       doTestProjectionPushDownDf(
-        edges,
+        edges.toDF(),
         Seq($"subject", $"objectUid"),
         None,
-        expectedEdges.map(select(0, 2))
+        expectedRows.map(select(0, 2))
       )
 
       doTestProjectionPushDownDf(
-        edges,
+        edges.toDF(),
         Seq($"subject", $"predicate", $"objectUid"),
         None,
-        expectedEdges
+        expectedRows
       )
 
       doTestProjectionPushDownDf(
-        edges,
+        edges.toDF(),
         Seq.empty,
         None,
-        expectedEdges
+        expectedRows
       )
     }
-
   }
 
 }

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestNodeSource.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestNodeSource.scala
@@ -769,7 +769,7 @@ class TestNodeSource extends AnyFunSpec with ShuffleExchangeTests
           reader
             .options(Map(
               NodesModeOption -> NodesModeTypedOption,
-              PartitionerOption -> s"$UidRangePartitionerOption",
+              PartitionerOption -> UidRangePartitionerOption,
               UidRangePartitionerUidsPerPartOption -> "7",
               UidRangePartitionerEstimatorOption -> MaxLeaseIdEstimatorOption,
               MaxLeaseIdEstimatorIdOption -> dgraph.highestUid.toString
@@ -832,7 +832,7 @@ class TestNodeSource extends AnyFunSpec with ShuffleExchangeTests
           reader
             .options(Map(
               NodesModeOption -> NodesModeTypedOption,
-              PartitionerOption -> s"$UidRangePartitionerOption",
+              PartitionerOption -> UidRangePartitionerOption,
               UidRangePartitionerUidsPerPartOption -> "7",
               UidRangePartitionerEstimatorOption -> MaxLeaseIdEstimatorOption,
               MaxLeaseIdEstimatorIdOption -> dgraph.highestUid.toString
@@ -1054,6 +1054,38 @@ class TestNodeSource extends AnyFunSpec with ShuffleExchangeTests
           Some(expectedPredicates.filter(p => Set("uid", "dgraph.type", "name").contains(p.predicateName))),
           expectedWideNodes.filter(row => !row.isNullAt(0) && !row.isNullAt(1) && !row.isNullAt(2)).map(select(0, 1, 2))
         )
+      }
+
+      lazy val expectedSubjectCounts = expectedWideNodes.toSeq.groupBy(_.getLong(0))
+        .mapValues(_.length).toSeq.sortBy(_._1).map(e => Row(e._1, e._2))
+      val subjectPartitioningTests = Seq(
+        ("distinct", (df: DataFrame) => df.select($"subject").distinct(), () => expectedSubjectCounts.map(row => Row(row.getLong(0)))),
+        ("groupBy", (df: DataFrame) => df.groupBy($"subject").count(), () => expectedSubjectCounts),
+        ("Window.partitionBy", (df: DataFrame) => df.select($"subject", count(lit(1)) over Window.partitionBy($"subject")),
+          () => expectedSubjectCounts.flatMap(row => row * row.getInt(1)) // all rows occur with cardinality of their count
+        ),
+        ("Window.partitionBy.orderBy", (df: DataFrame) => df.select($"subject", row_number() over Window.partitionBy($"subject").orderBy($"title")),
+          () => expectedSubjectCounts.flatMap(row => row ++ row.getInt(1)) // each row occurs with row_number up to their cardinality
+        )
+      )
+
+      // NOTE: there is no partitioning for wide nodes that does not support subject partitioning
+      // describe("without subject partitioning") { ... }
+
+      describe("with subject partitioning") {
+        val withPartitioning = () =>
+          reader
+            .options(Map(
+              NodesModeOption -> NodesModeWideOption,
+              PartitionerOption -> UidRangePartitionerOption,
+              UidRangePartitionerUidsPerPartOption -> "7",
+              UidRangePartitionerEstimatorOption -> MaxLeaseIdEstimatorOption,
+              MaxLeaseIdEstimatorIdOption -> dgraph.highestUid.toString
+            ))
+            .dgraph.nodes(dgraph.target)
+            .transform(removeDgraphWideNodes)
+
+        testForShuffleExchange(withPartitioning, subjectPartitioningTests, shuffleExpected = false)
       }
 
     }

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestNodeSource.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestNodeSource.scala
@@ -416,6 +416,7 @@ class TestNodeSource extends AnyFunSpec
             PartitionerOption -> s"$PredicatePartitionerOption+$UidRangePartitionerOption",
             PredicatePartitionerPredicatesOption -> "1",
             UidRangePartitionerUidsPerPartOption -> "1",
+            UidRangePartitionerEstimatorOption -> MaxLeaseIdEstimatorOption,
             MaxLeaseIdEstimatorIdOption -> dgraph.highestUid.toString
           ))
           .dgraph.nodes(dgraph.target)
@@ -517,6 +518,7 @@ class TestNodeSource extends AnyFunSpec
             .options(Map(
               PartitionerOption -> UidRangePartitionerOption,
               UidRangePartitionerUidsPerPartOption -> "7",
+              UidRangePartitionerEstimatorOption -> MaxLeaseIdEstimatorOption,
               MaxLeaseIdEstimatorIdOption -> dgraph.highestUid.toString
             ))
             .dgraph.nodes(target)

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestNodeSource.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestNodeSource.scala
@@ -397,31 +397,37 @@ class TestNodeSource extends AnyFunSpec with ShuffleExchangeTests
       )
     }
 
-    it("should load wide nodes with predicate partitioner") {
-      doTestLoadWideNodes(() =>
-        reader
-          .options(Map(
-            NodesModeOption -> NodesModeWideOption,
-            PartitionerOption -> PredicatePartitionerOption,
-            PredicatePartitionerPredicatesOption -> "1"
-          ))
-          .dgraph.nodes(dgraph.target)
-      )
+    Seq(
+      AlphaPartitionerOption,
+      GroupPartitionerOption,
+      PredicatePartitionerOption,
+      PredicateAndUidRangePartitionerOption
+    ).foreach { partitioner =>
+      it(s"should not load wide nodes with predicate $partitioner partitioner") {
+        val exception = intercept[RuntimeException] {
+          reader
+            .option(NodesModeOption, NodesModeWideOption)
+            .option(PartitionerOption, partitioner)
+            .dgraph.nodes(dgraph.target)
+        }
+        assert(exception.getMessage === f"Dgraph nodes cannot be read in wide mode with " +
+          f"any kind of predicate partitioning: $partitioner")
+      }
     }
 
-    it("should load wide nodes with predicate partitioner and uid ranges") {
-      doTestLoadWideNodes(() =>
-        reader
-          .options(Map(
-            NodesModeOption -> NodesModeWideOption,
-            PartitionerOption -> s"$PredicatePartitionerOption+$UidRangePartitionerOption",
-            PredicatePartitionerPredicatesOption -> "1",
-            UidRangePartitionerUidsPerPartOption -> "1",
-            UidRangePartitionerEstimatorOption -> MaxLeaseIdEstimatorOption,
-            MaxLeaseIdEstimatorIdOption -> dgraph.highestUid.toString
-          ))
-          .dgraph.nodes(dgraph.target)
-      )
+    Seq(
+      SingletonPartitionerOption,
+      UidRangePartitionerOption,
+      s"$SingletonPartitionerOption+$UidRangePartitionerOption"
+    ).foreach { partitioner =>
+      it(s"should load wide nodes with $partitioner partitioner") {
+        doTestLoadWideNodes(() =>
+          reader
+            .option(NodesModeOption, NodesModeWideOption)
+            .option(PartitionerOption, partitioner)
+            .dgraph.nodes(dgraph.target)
+        )
+      }
     }
 
     it("should load typed nodes in chunks") {
@@ -585,10 +591,7 @@ class TestNodeSource extends AnyFunSpec with ShuffleExchangeTests
 
     lazy val wideNodes =
       reader
-        .options(Map(
-          NodesModeOption -> NodesModeWideOption,
-          PartitionerOption -> PredicatePartitionerOption
-        ))
+        .option(NodesModeOption, NodesModeWideOption)
         .dgraph.nodes(dgraph.target)
         .transform(removeDgraphWideNodes)
 
@@ -879,7 +882,7 @@ class TestNodeSource extends AnyFunSpec with ShuffleExchangeTests
           reader
             .options(Map(
               NodesModeOption -> NodesModeTypedOption,
-              PartitionerOption -> s"$PredicatePartitionerOption+$UidRangePartitionerOption",
+              PartitionerOption -> PredicateAndUidRangePartitionerOption,
               PredicatePartitionerPredicatesOption -> "2",
               UidRangePartitionerUidsPerPartOption -> "7",
               UidRangePartitionerEstimatorOption -> MaxLeaseIdEstimatorOption,

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestNodeSource.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestNodeSource.scala
@@ -492,7 +492,7 @@ class TestNodeSource extends AnyFunSpec with ShuffleExchangeTests
         Predicate("running_time", "int"),
         Predicate("title", "string"),
       )
-      assert(partitions === Seq(Some(Partition(targets).has(predicates).langs(Set("title")))))
+      assert(partitions === Seq(Some(Partition(targets).has(predicates).getAll.langs(Set("title")))))
     }
 
     it("should load as predicate partitions") {
@@ -536,9 +536,10 @@ class TestNodeSource extends AnyFunSpec with ShuffleExchangeTests
           case _ => None
         }
 
+      val properties = Set("dgraph.type", "name", "release_date", "revenue", "running_time", "title")
       val expected = Set(
-        Some(Partition(targets).has(Set("dgraph.type", "name", "release_date", "revenue", "running_time", "title"), Set.empty).langs(Set("title")).range(1, 8)),
-        Some(Partition(targets).has(Set("dgraph.type", "name", "release_date", "revenue", "running_time", "title"), Set.empty).langs(Set("title")).range(8, 15)),
+        Some(Partition(targets).has(properties, Set.empty).getAll.langs(Set("title")).range(1, 8)),
+        Some(Partition(targets).has(properties, Set.empty).getAll.langs(Set("title")).range(8, 15)),
       )
 
       assert(partitions.toSet === expected)

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestTriplesSource.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestTriplesSource.scala
@@ -472,7 +472,7 @@ class TestTriplesSource extends AnyFunSpec with ShuffleExchangeTests
       val partitions =
         reader
           .options(Map(
-            PartitionerOption -> s"$UidRangePartitionerOption",
+            PartitionerOption -> UidRangePartitionerOption,
             UidRangePartitionerUidsPerPartOption -> "7",
             MaxLeaseIdEstimatorIdOption -> dgraph.highestUid.toString
           ))
@@ -495,7 +495,7 @@ class TestTriplesSource extends AnyFunSpec with ShuffleExchangeTests
       val partitions =
         reader
           .options(Map(
-            PartitionerOption -> s"$PredicatePartitionerOption+$UidRangePartitionerOption",
+            PartitionerOption -> PredicateAndUidRangePartitionerOption,
             PredicatePartitionerPredicatesOption -> "2",
             UidRangePartitionerUidsPerPartOption -> "5",
             MaxLeaseIdEstimatorIdOption -> dgraph.highestUid.toString
@@ -868,7 +868,7 @@ class TestTriplesSource extends AnyFunSpec with ShuffleExchangeTests
       val withoutPartitioning = () =>
         reader
           .options(Map(
-            PartitionerOption -> s"$UidRangePartitionerOption",
+            PartitionerOption -> UidRangePartitionerOption,
             UidRangePartitionerUidsPerPartOption -> "7",
             UidRangePartitionerEstimatorOption -> MaxLeaseIdEstimatorOption,
             MaxLeaseIdEstimatorIdOption -> dgraph.highestUid.toString
@@ -918,7 +918,7 @@ class TestTriplesSource extends AnyFunSpec with ShuffleExchangeTests
       val withPartitioning = () =>
         reader
           .options(Map(
-            PartitionerOption -> s"$UidRangePartitionerOption",
+            PartitionerOption -> UidRangePartitionerOption,
             UidRangePartitionerUidsPerPartOption -> "7",
             UidRangePartitionerEstimatorOption -> MaxLeaseIdEstimatorOption,
             MaxLeaseIdEstimatorIdOption -> dgraph.highestUid.toString
@@ -957,7 +957,7 @@ class TestTriplesSource extends AnyFunSpec with ShuffleExchangeTests
       val withPartitioning = () =>
         reader
           .options(Map(
-            PartitionerOption -> s"$PredicatePartitionerOption+$UidRangePartitionerOption",
+            PartitionerOption -> PredicateAndUidRangePartitionerOption,
             PredicatePartitionerPredicatesOption -> "2",
             UidRangePartitionerUidsPerPartOption -> "5",
             UidRangePartitionerEstimatorOption -> MaxLeaseIdEstimatorOption,

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestTriplesSource.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestTriplesSource.scala
@@ -18,11 +18,15 @@ package uk.co.gresearch.spark.dgraph.connector.sources
 
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Expression, In, Literal}
+import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.datasources.v2.DataSourceRDDPartition
+import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
+import org.apache.spark.sql.expressions.Window
+import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{LongType, StringType}
 import org.scalatest.funspec.AnyFunSpec
 import uk.co.gresearch.spark.dgraph.connector._
-import uk.co.gresearch.spark.dgraph.connector.sources.TestTriplesSource.removeDgraphTriples
+import uk.co.gresearch.spark.dgraph.connector.sources.TestTriplesSource.{ExtendedRow, removeDgraphTriples}
 import uk.co.gresearch.spark.dgraph.{DgraphCluster, DgraphTestCluster}
 
 import java.sql.Timestamp
@@ -849,6 +853,176 @@ class TestTriplesSource extends AnyFunSpec
       )
     }
 
+    it("should report single partitioning") {
+      val target = dgraph.target
+      val df =
+        reader
+          .option(PartitionerOption, SingletonPartitionerOption)
+          .dgraph.triples(target)
+          .repartition(1)
+      df.queryExecution.optimizedPlan
+      print()
+    }
+
+    def containsShuffleExchangeExec(plan: SparkPlan): Boolean = plan match {
+      case _: ShuffleExchangeExec => true
+      case p => p.children.exists(containsShuffleExchangeExec)
+    }
+
+    val predicatePartitioningTests = Seq(
+      ("distinct", (df: DataFrame) => df.select($"predicate").distinct(), Seq(
+        Row("dgraph.type"), Row("director"), Row("name"), Row("release_date"),
+        Row("revenue"), Row("running_time"), Row("starring"), Row("title")
+      )),
+      ("groupBy", (df: DataFrame) => df.groupBy($"predicate").count(), Seq(
+        Row("dgraph.type", 10), Row("director", 3), Row("name", 6), Row("release_date", 4),
+        Row("revenue", 4), Row("running_time", 4), Row("starring", 9), Row("title", 3)
+      )),
+      ("Window.partitionBy", (df: DataFrame) => df.select($"predicate", count(lit(1)) over Window.partitionBy($"predicate")), Seq(
+        Row("dgraph.type", 10), Row("director", 3), Row("name", 6), Row("release_date", 4),
+        Row("revenue", 4), Row("running_time", 4), Row("starring", 9), Row("title", 3)
+      ).flatMap(row => row * row.getInt(1))),  // all rows occur with cardinality of their count
+      ("Window.partitionBy.orderBy", (df: DataFrame) => df.select($"predicate", row_number() over Window.partitionBy($"predicate").orderBy($"subject")), Seq(
+        Row("dgraph.type", 10), Row("director", 3), Row("name", 6), Row("release_date", 4),
+        Row("revenue", 4), Row("running_time", 4), Row("starring", 9), Row("title", 3)
+      ).flatMap(row => row ++ row.getInt(1))),  // each row occurs with row_number up to their cardinality
+    )
+
+    def testPartitioning(df: () => DataFrame,
+                         tests: Seq[(String, DataFrame => DataFrame, Seq[Row])],
+                         shuffleExpected: Boolean): Unit = {
+      testPartitioning2(df, tests.map(test => (test._1, test._2, () => test._3)), shuffleExpected = shuffleExpected)
+    }
+
+    def testPartitioning2(df: () => DataFrame,
+                         tests: Seq[(String, DataFrame => DataFrame, () => Seq[Row])],
+                         shuffleExpected: Boolean): Unit = {
+      val label = if (shuffleExpected) "shuffle" else "reuse partitioning"
+      tests.foreach {
+        case (test, op, expected) =>
+          it(f"should $label for $test") {
+            val data = op(removeDgraphTriples(df()))
+            val plan = data.queryExecution.executedPlan
+            assert(containsShuffleExchangeExec(plan) === shuffleExpected, plan)
+            assert(data.sort(data.columns.map(col): _*).collect() === expected())
+          }
+      }
+    }
+
+    describe("without predicate partitioning") {
+      val withoutPartitioning = () =>
+        reader
+          .options(Map(
+            PartitionerOption -> s"$UidRangePartitionerOption",
+            UidRangePartitionerUidsPerPartOption -> "7",
+            MaxLeaseIdEstimatorIdOption -> dgraph.highestUid.toString
+          ))
+          .dgraph.triples(dgraph.target)
+          .where(!$"predicate".contains("@"))
+
+      testPartitioning(withoutPartitioning, predicatePartitioningTests, shuffleExpected = true)
+    }
+
+    describe("with predicate partitioning") {
+      val withPartitioning = () =>
+        reader
+          .option(PartitionerOption, PredicatePartitionerOption)
+          .option(PredicatePartitionerPredicatesOption, "2")
+          .dgraph.triples(dgraph.target)
+          .where(!$"predicate".contains("@"))
+
+      testPartitioning(withPartitioning, predicatePartitioningTests, shuffleExpected = false)
+    }
+
+    val subjectPartitioningTests = Seq(
+      ("distinct", (df: DataFrame) => df.select($"subject").distinct(), () => dgraph.allUids.sorted.map(Row(_))),
+      ("groupBy", (df: DataFrame) => df.groupBy($"subject").count(), () => Seq(
+        Row(dgraph.han, 2), Row(dgraph.irvin, 2), Row(dgraph.leia, 2), Row(dgraph.luke, 2),
+        Row(dgraph.lucas, 2), Row(dgraph.richard, 2),
+        Row(dgraph.st1, 4), Row(dgraph.sw1, 9), Row(dgraph.sw2, 9), Row(dgraph.sw3, 9)
+      ).sortBy(_.getLong(0))),
+      ("Window.partitionBy", (df: DataFrame) => df.select($"subject", count(lit(1)) over Window.partitionBy($"subject")), () => Seq(
+        Row(dgraph.han, 2), Row(dgraph.irvin, 2), Row(dgraph.leia, 2), Row(dgraph.luke, 2),
+        Row(dgraph.lucas, 2), Row(dgraph.richard, 2),
+        Row(dgraph.st1, 4), Row(dgraph.sw1, 9), Row(dgraph.sw2, 9), Row(dgraph.sw3, 9)
+      ).sortBy(_.getLong(0)).flatMap(row => row * row.getInt(1))),  // all rows occur with cardinality of their count
+      ("Window.partitionBy.orderBy", (df: DataFrame) => df.select($"subject", row_number() over Window.partitionBy($"subject").orderBy($"predicate")), () => Seq(
+        Row(dgraph.han, 2), Row(dgraph.irvin, 2), Row(dgraph.leia, 2), Row(dgraph.luke, 2),
+        Row(dgraph.lucas, 2), Row(dgraph.richard, 2),
+        Row(dgraph.st1, 4), Row(dgraph.sw1, 9), Row(dgraph.sw2, 9), Row(dgraph.sw3, 9)
+      ).sortBy(_.getLong(0)).flatMap(row => row ++ row.getInt(1))),  // each row occurs with row_number up to their cardinality
+    )
+
+    describe("without subject partitioning") {
+      val withoutPartitioning = () =>
+        reader
+          .option(PartitionerOption, PredicatePartitionerOption)
+          .option(PredicatePartitionerPredicatesOption, "2")
+          .dgraph.triples(dgraph.target)
+          .where(!$"predicate".contains("@"))
+
+      testPartitioning2(withoutPartitioning, subjectPartitioningTests, shuffleExpected = true)
+    }
+
+    describe("with subject partitioning") {
+      val withPartitioning = () =>
+        reader
+          .options(Map(
+            PartitionerOption -> s"$UidRangePartitionerOption",
+            UidRangePartitionerUidsPerPartOption -> "7",
+            MaxLeaseIdEstimatorIdOption -> dgraph.highestUid.toString
+          ))
+          .dgraph.triples(dgraph.target)
+          .where(!$"predicate".contains("@"))
+
+      testPartitioning2(withPartitioning, subjectPartitioningTests, shuffleExpected = false)
+    }
+
+    // Array([3,dgraph.type], [3,release_date], [3,revenue], [3,running_time], [4,dgraph.type], [4,name], [5,dgraph.type], [5,name], [6,dgraph.type], [6,director], [6,release_date], [6,revenue], [6,running_time], [6,starring], [6,title], [7,dgraph.type], [7,name], [8,dgraph.type], [8,director], [8,release_date], [8,revenue], [8,running_time], [8,starring], [8,title], [9,dgraph.type], [9,director], [9,release_date], [9,revenue], [9,running_time], [9,starring], [9,title], [10,dgraph.type], [10,name], [11,dgraph.type], [11,name], [12,dgraph.type], [12,name])
+
+    val subjectAndPredicatePartitioningTests = Seq(
+      ("distinct", (df: DataFrame) => df.select($"subject", $"predicate").distinct(),
+        () => TriplesSourceExpecteds(dgraph).getExpectedTypedTriples.map(t => Row(t.subject, t.predicate))
+          .toSeq.sortBy(row => (row.getLong(0), row.getString(1)))
+      ),
+      ("groupBy", (df: DataFrame) => df.groupBy($"subject", $"predicate").count(), () => Seq(
+        Row("dgraph.type", 11), Row("director", 3), Row("name", 6), Row("release_date", 4),
+        Row("revenue", 4), Row("running_time", 4), Row("starring", 9), Row("title", 3)
+      )),
+      ("Window.partitionBy", (df: DataFrame) => df.select($"subject", $"predicate", count(lit(1)) over Window.partitionBy($"subject", $"predicate")), () => Seq(
+        Row("dgraph.type", 11), Row("director", 3), Row("name", 6), Row("release_date", 4),
+        Row("revenue", 4), Row("running_time", 4), Row("starring", 9), Row("title", 3)
+      ).flatMap(row => row * row.getInt(1))),  // all rows occur with cardinality of their count
+      ("Window.partitionBy.orderBy", (df: DataFrame) => df.select($"subject", $"predicate", row_number() over Window.partitionBy($"subject", $"predicate").orderBy($"objectType")), () => Seq(
+        Row("dgraph.type", 11), Row("director", 3), Row("name", 6), Row("release_date", 4),
+        Row("revenue", 4), Row("running_time", 4), Row("starring", 9), Row("title", 3)
+      ).flatMap(row => row ++ row.getInt(1))),  // each row occurs with row_number up to their cardinality
+    )
+
+    describe("without subject and predicate partitioning") {
+      val withoutPartitioning = () =>
+        reader
+          .option(PartitionerOption, PredicatePartitionerOption)
+          .option(PredicatePartitionerPredicatesOption, "2")
+          .dgraph.triples(dgraph.target)
+
+      testPartitioning2(withoutPartitioning, subjectAndPredicatePartitioningTests, shuffleExpected = true)
+    }
+
+    describe("with subject and predicate partitioning") {
+      val withPartitioning = () =>
+        reader
+          .options(Map(
+            PartitionerOption -> s"$PredicatePartitionerOption+$UidRangePartitionerOption",
+            PredicatePartitionerPredicatesOption -> "2",
+            UidRangePartitionerUidsPerPartOption -> "5",
+            MaxLeaseIdEstimatorIdOption -> dgraph.highestUid.toString
+          ))
+          .dgraph.triples(dgraph.target)
+
+      testPartitioning2(withPartitioning, subjectAndPredicatePartitioningTests, shuffleExpected = false)
+    }
+
   }
 
 }
@@ -1002,6 +1176,11 @@ object TestTriplesSource {
     import triples.sparkSession.implicits._
     val dgraphNodeUids = triples.where($"predicate" === "dgraph.type" && $"objectString".startsWith("dgraph.")).select($"subject").distinct().as[Long].collect()
     triples.where(!$"subject".isin(dgraphNodeUids: _*))
+  }
+
+  implicit class ExtendedRow(row: Row) {
+    def *(n: Int): Seq[Row] = Seq.fill(n)(row)
+    def ++(n: Int): Seq[Row] = Seq.fill(n)(row).zipWithIndex.map { case (row, idx) => Row(row.get(0), idx+1) }
   }
 
 }

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestTriplesSource.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestTriplesSource.scala
@@ -443,7 +443,7 @@ class TestTriplesSource extends AnyFunSpec with ShuffleExchangeTests
           case p: DataSourceRDDPartition => Some(p.inputPartition)
           case _ => None
         }
-      assert(partitions === Seq(Some(Partition(targets).has(predicates).langs(Set("title")))))
+      assert(partitions === Seq(Some(Partition(targets).has(predicates).getAll.langs(Set("title")))))
     }
 
     it("should load as predicate partitions") {
@@ -458,11 +458,12 @@ class TestTriplesSource extends AnyFunSpec with ShuffleExchangeTests
           case _ => None
         }
 
+      val targets = Seq(Target(dgraph.target))
       val expected = Set(
-        Some(Partition(Seq(Target(dgraph.target))).has(Set("release_date"), Set("starring")).getAll),
-        Some(Partition(Seq(Target(dgraph.target))).has(Set("running_time"), Set("director")).getAll),
-        Some(Partition(Seq(Target(dgraph.target))).has(Set("dgraph.type", "name"), Set.empty).getAll),
-        Some(Partition(Seq(Target(dgraph.target))).has(Set("revenue", "title"), Set.empty).langs(Set("title")).getAll),
+        Some(Partition(targets).has(Set("release_date"), Set("starring")).getAll),
+        Some(Partition(targets).has(Set("running_time"), Set("director")).getAll),
+        Some(Partition(targets).has(Set("dgraph.type", "name"), Set.empty).getAll),
+        Some(Partition(targets).has(Set("revenue", "title"), Set.empty).langs(Set("title")).getAll),
       )
 
       assert(partitions.toSet === expected)
@@ -483,9 +484,10 @@ class TestTriplesSource extends AnyFunSpec with ShuffleExchangeTests
           case _ => None
         }
 
+      val targets = Seq(Target(dgraph.target))
       val expected = Set(
-        Some(Partition(Seq(Target(dgraph.target)), Set(Has(predicates), LangDirective(Set("title")), UidRange(Uid(1), Uid(8))))),
-        Some(Partition(Seq(Target(dgraph.target)), Set(Has(predicates), LangDirective(Set("title")), UidRange(Uid(8), Uid(15))))),
+        Some(Partition(targets).has(predicates).getAll.langs(Set("title")).range(1, 8)),
+        Some(Partition(targets).has(predicates).getAll.langs(Set("title")).range(8, 15)),
       )
 
       assert(partitions.toSet === expected)
@@ -509,11 +511,12 @@ class TestTriplesSource extends AnyFunSpec with ShuffleExchangeTests
 
       val ranges = Seq(UidRange(Uid(1), Uid(6)), UidRange(Uid(6), Uid(11)), UidRange(Uid(11), Uid(16)))
 
+      val targets = Seq(Target(dgraph.target))
       val expected = Set(
-        Partition(Seq(Target(dgraph.target))).has(Set("revenue", "title"), Set.empty).langs(Set("title")).getAll,
-        Partition(Seq(Target(dgraph.target))).has(Set("release_date"), Set("starring")).getAll,
-        Partition(Seq(Target(dgraph.target))).has(Set("dgraph.type", "name"), Set.empty).getAll,
-        Partition(Seq(Target(dgraph.target))).has(Set("running_time"), Set("director")).getAll
+        Partition(targets).has(Set("revenue", "title"), Set.empty).langs(Set("title")).getAll,
+        Partition(targets).has(Set("release_date"), Set("starring")).getAll,
+        Partition(targets).has(Set("dgraph.type", "name"), Set.empty).getAll,
+        Partition(targets).has(Set("running_time"), Set("director")).getAll
       ).flatMap(partition => ranges.map(range => Some(partition.copy(operators = partition.operators + range))))
 
       assert(partitions.toSet === expected)

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestTriplesSource.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestTriplesSource.scala
@@ -18,10 +18,7 @@ package uk.co.gresearch.spark.dgraph.connector.sources
 
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Expression, In, Literal}
-import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
 import org.apache.spark.sql.execution.datasources.v2.DataSourceRDDPartition
-import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{LongType, StringType}
@@ -40,7 +37,7 @@ class TestTriplesSource extends AnyFunSpec with ShuffleExchangeTests
 
   import spark.implicits._
 
-  describe("TriplesDataSource") {
+  describe("TriplesSource") {
 
     lazy val expecteds = TriplesSourceExpecteds(dgraph)
     lazy val expectedTypedTriples = expecteds.getExpectedTypedTriples

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestTriplesSource.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestTriplesSource.scala
@@ -873,9 +873,11 @@ class TestTriplesSource extends AnyFunSpec with ShuffleExchangeTests
           .options(Map(
             PartitionerOption -> s"$UidRangePartitionerOption",
             UidRangePartitionerUidsPerPartOption -> "7",
+            UidRangePartitionerEstimatorOption -> MaxLeaseIdEstimatorOption,
             MaxLeaseIdEstimatorIdOption -> dgraph.highestUid.toString
           ))
           .dgraph.triples(dgraph.target)
+          .transform(removeDgraphTriples)
 
       testForShuffleExchange(withoutPartitioning, predicatePartitioningTests, shuffleExpected = true)
     }
@@ -886,6 +888,7 @@ class TestTriplesSource extends AnyFunSpec with ShuffleExchangeTests
           .option(PartitionerOption, PredicatePartitionerOption)
           .option(PredicatePartitionerPredicatesOption, "2")
           .dgraph.triples(dgraph.target)
+          .transform(removeDgraphTriples)
 
       testForShuffleExchange(withPartitioning, predicatePartitioningTests, shuffleExpected = false)
     }
@@ -909,6 +912,7 @@ class TestTriplesSource extends AnyFunSpec with ShuffleExchangeTests
           .option(PartitionerOption, PredicatePartitionerOption)
           .option(PredicatePartitionerPredicatesOption, "2")
           .dgraph.triples(dgraph.target)
+          .transform(removeDgraphTriples)
 
       testForShuffleExchange(withoutPartitioning, subjectPartitioningTests, shuffleExpected = true)
     }
@@ -919,9 +923,11 @@ class TestTriplesSource extends AnyFunSpec with ShuffleExchangeTests
           .options(Map(
             PartitionerOption -> s"$UidRangePartitionerOption",
             UidRangePartitionerUidsPerPartOption -> "7",
+            UidRangePartitionerEstimatorOption -> MaxLeaseIdEstimatorOption,
             MaxLeaseIdEstimatorIdOption -> dgraph.highestUid.toString
           ))
           .dgraph.triples(dgraph.target)
+          .transform(removeDgraphTriples)
 
       testForShuffleExchange(withPartitioning, subjectPartitioningTests, shuffleExpected = false)
     }
@@ -945,6 +951,7 @@ class TestTriplesSource extends AnyFunSpec with ShuffleExchangeTests
           .option(PartitionerOption, PredicatePartitionerOption)
           .option(PredicatePartitionerPredicatesOption, "2")
           .dgraph.triples(dgraph.target)
+          .transform(removeDgraphTriples)
 
       testForShuffleExchange(withoutPartitioning, subjectAndPredicatePartitioningTests, shuffleExpected = true)
     }
@@ -956,9 +963,11 @@ class TestTriplesSource extends AnyFunSpec with ShuffleExchangeTests
             PartitionerOption -> s"$PredicatePartitionerOption+$UidRangePartitionerOption",
             PredicatePartitionerPredicatesOption -> "2",
             UidRangePartitionerUidsPerPartOption -> "5",
+            UidRangePartitionerEstimatorOption -> MaxLeaseIdEstimatorOption,
             MaxLeaseIdEstimatorIdOption -> dgraph.highestUid.toString
           ))
           .dgraph.triples(dgraph.target)
+          .transform(removeDgraphTriples)
 
       testForShuffleExchange(withPartitioning, subjectAndPredicatePartitioningTests, shuffleExpected = false)
     }

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestTriplesSource.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestTriplesSource.scala
@@ -854,29 +854,6 @@ class TestTriplesSource extends AnyFunSpec with ShuffleExchangeTests
       )
     }
 
-    def containsShuffleExchangeExec(plan: SparkPlan): Boolean = plan match {
-      case _: ShuffleExchangeExec => true
-      case p => p.children.exists(containsShuffleExchangeExec)
-    }
-
-    def testPartitioning(df: () => DataFrame,
-                         tests: Seq[(String, DataFrame => DataFrame, () => Seq[Row])],
-                         shuffleExpected: Boolean): Unit = {
-      val label = if (shuffleExpected) "shuffle" else "reuse partitioning"
-      tests.foreach {
-        case (test, op, expected) =>
-          it(f"should $label for $test") {
-            val data = op(removeDgraphTriples(df()))
-            val plan = data.queryExecution.executedPlan match {
-              case p: AdaptiveSparkPlanExec => p.executedPlan
-              case p => p
-            }
-            assert(containsShuffleExchangeExec(plan) === shuffleExpected, plan)
-            assert(data.sort(data.columns.map(col): _*).collect() === expected())
-          }
-      }
-    }
-
     lazy val expectedPredicateCounts = expectedTypedTriples.toSeq.groupBy(_.predicate)
       .mapValues(_.length).toSeq.sortBy(_._1).map(e => Row(e._1, e._2))
     val predicatePartitioningTests = Seq(
@@ -900,7 +877,7 @@ class TestTriplesSource extends AnyFunSpec with ShuffleExchangeTests
           ))
           .dgraph.triples(dgraph.target)
 
-      testPartitioning(withoutPartitioning, predicatePartitioningTests, shuffleExpected = true)
+      testForShuffleExchange(withoutPartitioning, predicatePartitioningTests, shuffleExpected = true)
     }
 
     describe("with predicate partitioning") {
@@ -910,7 +887,7 @@ class TestTriplesSource extends AnyFunSpec with ShuffleExchangeTests
           .option(PredicatePartitionerPredicatesOption, "2")
           .dgraph.triples(dgraph.target)
 
-      testPartitioning(withPartitioning, predicatePartitioningTests, shuffleExpected = false)
+      testForShuffleExchange(withPartitioning, predicatePartitioningTests, shuffleExpected = false)
     }
 
     lazy val expectedSubjectCounts = expectedTypedTriples.toSeq.groupBy(_.subject)
@@ -933,7 +910,7 @@ class TestTriplesSource extends AnyFunSpec with ShuffleExchangeTests
           .option(PredicatePartitionerPredicatesOption, "2")
           .dgraph.triples(dgraph.target)
 
-      testPartitioning(withoutPartitioning, subjectPartitioningTests, shuffleExpected = true)
+      testForShuffleExchange(withoutPartitioning, subjectPartitioningTests, shuffleExpected = true)
     }
 
     describe("with subject partitioning") {
@@ -946,7 +923,7 @@ class TestTriplesSource extends AnyFunSpec with ShuffleExchangeTests
           ))
           .dgraph.triples(dgraph.target)
 
-      testPartitioning(withPartitioning, subjectPartitioningTests, shuffleExpected = false)
+      testForShuffleExchange(withPartitioning, subjectPartitioningTests, shuffleExpected = false)
     }
 
     lazy val expectedSubjectAndPredicateCounts = expectedTypedTriples.toSeq.groupBy(t => (t.subject, t.predicate))
@@ -969,7 +946,7 @@ class TestTriplesSource extends AnyFunSpec with ShuffleExchangeTests
           .option(PredicatePartitionerPredicatesOption, "2")
           .dgraph.triples(dgraph.target)
 
-      testPartitioning(withoutPartitioning, subjectAndPredicatePartitioningTests, shuffleExpected = true)
+      testForShuffleExchange(withoutPartitioning, subjectAndPredicatePartitioningTests, shuffleExpected = true)
     }
 
     describe("with subject and predicate partitioning") {
@@ -983,7 +960,7 @@ class TestTriplesSource extends AnyFunSpec with ShuffleExchangeTests
           ))
           .dgraph.triples(dgraph.target)
 
-      testPartitioning(withPartitioning, subjectAndPredicatePartitioningTests, shuffleExpected = false)
+      testForShuffleExchange(withPartitioning, subjectAndPredicatePartitioningTests, shuffleExpected = false)
     }
 
   }
@@ -1139,11 +1116,6 @@ object TestTriplesSource {
     import triples.sparkSession.implicits._
     val dgraphNodeUids = triples.where($"predicate" === "dgraph.type" && $"objectString".startsWith("dgraph.")).select($"subject").distinct().as[Long].collect()
     triples.where(!$"subject".isin(dgraphNodeUids: _*))
-  }
-
-  implicit class ExtendedRow(row: Row) {
-    def *(n: Int): Seq[Row] = Seq.fill(n)(row)
-    def ++(n: Int): Seq[Row] = Seq.fill(n)(row).zipWithIndex.map { case (row, idx) => Row(row.toSeq.init :+ (idx+1): _*) }
   }
 
 }

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/package.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/package.scala
@@ -1,0 +1,12 @@
+package uk.co.gresearch.spark.dgraph.connector
+
+import org.apache.spark.sql.Row
+
+package object sources {
+
+  implicit class ExtendedRow(row: Row) {
+    def *(n: Int): Seq[Row] = Seq.fill(n)(row)
+    def ++(n: Int): Seq[Row] = Seq.fill(n)(row).zipWithIndex.map { case (row, idx) => Row(row.toSeq.init :+ (idx+1): _*) }
+  }
+
+}


### PR DESCRIPTION
## Checklist before submitting

- [X] Did you read the [contributing guide](https://github.com/G-Research/spark-dgraph-connector/blob/contributing-guidelines/CONTRIBUTING.md)?
- [X] Did you update the docs?
- [X] Did you write any tests to validate this change?  

## Description

With release of Spark 3.4, data sources can report the existing ordering of read data. This allows Spark to avoid ordering data when the source satisfies that already.

## Review process for approval

1. All tests and other checks must succeed.
2. At least one core contributors must review and approve.
3. If a core contributor requests changes, they must be addressed.