### PR TITLE
Make maxLeaseId / maxUID an Option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [UNRELEASED] - YYYY-MM-DD
+
+### Fixed
+- Work with maxUID values that cannot be parsed
+- Handle maxUID values larger than Long.MaxValue
+
 ## [0.9.0] - 2022-07-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -621,8 +621,9 @@ The number of uids of each underlying partition has to be estimated. Once the nu
 the partition is further split into ranges of that uid space.
 
 The space of existing `uids` is split into ranges of `N` `uids` per partition. The `N` defaults to `1000000`
-and can be configured via `dgraph.partitioner.uidRange.uidsPerPartition`. The `uid`s are allocated to
-partitions in ascending order. If vertex size is skewed and a function of `uid`, then partitions will be skewed as well.
+and can be configured via `dgraph.partitioner.uidRange.uidsPerPartition`. The `uid`s are allocated to partitions in ascending order.
+Such a split will not be done if more than `dgraph.partitioner.uidRange.maxPartitions` partitions would be created. This defaults to `10000`.
+If vertex size is skewed and a function of `uid`, then partitions will be skewed as well.
 
 Note: With uid partitioning, the chunk size configured via `dgraph.chunkSize` should be at least a 10th of
 the number of uids per partition configured via `dgraph.partitioner.uidRange.uidsPerPartition` to avoid

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,14 @@
       <version>2.9.0</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>16.0.1</version>
+      <!-- provided by Spark -->
+      <scope>provided</scope>
+    </dependency>
+
     <!-- Test -->
     <dependency>
       <groupId>org.scalatest</groupId>

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/ClusterState.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/ClusterState.scala
@@ -57,7 +57,7 @@ object ClusterState extends Logging {
       Some(n.getAsLong)
     } catch {
       case e: NumberFormatException =>
-        if (!n.isNumber) log.warn("Cannot parse as number", e)
+        try { n.getAsBigInteger } catch { case _: Throwable => log.warn("Cannot parse as number", e) }
         None
     }
   }

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/package.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/package.scala
@@ -190,6 +190,8 @@ package object connector {
   val PredicatePartitionerPredicatesDefault: Int = 1000
   val UidRangePartitionerUidsPerPartOption: String = "dgraph.partitioner.uidRange.uidsPerPartition"
   val UidRangePartitionerUidsPerPartDefault: Int = 1000000
+  val UidRangePartitionerMaxPartsOption: String = "dgraph.partitioner.uidRange.maxPartitions"
+  val UidRangePartitionerMaxPartsDefault: Int = 10000
   val UidRangePartitionerEstimatorOption: String = "dgraph.partitioner.uidRange.estimator"
   val MaxLeaseIdEstimatorOption: String = "maxLeaseId"
   val UidRangePartitionerEstimatorDefault: String = MaxLeaseIdEstimatorOption

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/ConfigPartitionerOption.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/ConfigPartitionerOption.scala
@@ -47,11 +47,12 @@ class ConfigPartitionerOption extends PartitionerProviderOption
           getIntOption(PredicatePartitionerPredicatesOption, options, PredicatePartitionerPredicatesDefault))
       case UidRangePartitionerOption =>
         val uidsPerPartition = getIntOption(UidRangePartitionerUidsPerPartOption, options, UidRangePartitionerUidsPerPartDefault)
+        val maxPartitions = getIntOption(UidRangePartitionerMaxPartsOption, options, UidRangePartitionerMaxPartsDefault)
         val estimator = getEstimatorOption(UidRangePartitionerEstimatorOption, options, UidRangePartitionerEstimatorDefault, clusterState)
         val targets = getAllClusterTargets(clusterState)
         val singleton = SingletonPartitioner(targets, schema)
-        UidRangePartitioner(singleton, uidsPerPartition, estimator)
-      case option if option.endsWith(s"+${UidRangePartitionerOption}") =>
+        UidRangePartitioner(singleton, uidsPerPartition, maxPartitions, estimator)
+      case option if option.endsWith(s"+$UidRangePartitionerOption") =>
         val name = option.substring(0, option.indexOf('+'))
         val partitioner = getPartitioner(name, schema, clusterState, transaction, options)
         getPartitioner(UidRangePartitionerOption, schema, clusterState, transaction, options)

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/EstimatorProviderOption.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/EstimatorProviderOption.scala
@@ -16,6 +16,7 @@
 
 package uk.co.gresearch.spark.dgraph.connector.partitioner
 
+import com.google.common.primitives.UnsignedLong
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import uk.co.gresearch.spark.dgraph.connector._
 
@@ -26,7 +27,7 @@ trait EstimatorProviderOption extends ConfigParser with ClusterStateHelper with 
     val name = getStringOption(option, options, default)
     name match {
       case MaxLeaseIdEstimatorOption =>
-        val maxLeaseId = getIntOption(MaxLeaseIdEstimatorIdOption, options).map(BigInt.apply)
+        val maxLeaseId = getIntOption(MaxLeaseIdEstimatorIdOption, options).map(UnsignedLong.valueOf(_))
         maxLeaseId.foreach(id => log.warn(s"using configured maxLeaseId=$id for uid cardinality estimator"))
         UidCardinalityEstimator.forMaxLeaseId(maxLeaseId.orElse(clusterState.maxLeaseId))
       case _ => throw new IllegalArgumentException(s"Unknown uid cardinality estimator: $name")

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/EstimatorProviderOption.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/EstimatorProviderOption.scala
@@ -26,7 +26,7 @@ trait EstimatorProviderOption extends ConfigParser with ClusterStateHelper with 
     val name = getStringOption(option, options, default)
     name match {
       case MaxLeaseIdEstimatorOption =>
-        val maxLeaseId = getIntOption(MaxLeaseIdEstimatorIdOption, options).map(_.toLong)
+        val maxLeaseId = getIntOption(MaxLeaseIdEstimatorIdOption, options).map(BigInt.apply)
         maxLeaseId.foreach(id => log.warn(s"using configured maxLeaseId=$id for uid cardinality estimator"))
         UidCardinalityEstimator.forMaxLeaseId(maxLeaseId.orElse(clusterState.maxLeaseId))
       case _ => throw new IllegalArgumentException(s"Unknown uid cardinality estimator: $name")

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/EstimatorProviderOption.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/EstimatorProviderOption.scala
@@ -28,7 +28,7 @@ trait EstimatorProviderOption extends ConfigParser with ClusterStateHelper with 
       case MaxLeaseIdEstimatorOption =>
         val maxLeaseId = getIntOption(MaxLeaseIdEstimatorIdOption, options).map(_.toLong)
         maxLeaseId.foreach(id => log.warn(s"using configured maxLeaseId=$id for uid cardinality estimator"))
-        UidCardinalityEstimator.forMaxLeaseId(maxLeaseId.getOrElse(clusterState.maxLeaseId))
+        UidCardinalityEstimator.forMaxLeaseId(maxLeaseId.orElse(clusterState.maxLeaseId))
       case _ => throw new IllegalArgumentException(s"Unknown uid cardinality estimator: $name")
     }
   }

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/UidCardinalityEstimator.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/UidCardinalityEstimator.scala
@@ -48,9 +48,9 @@ abstract class UidCardinalityEstimatorBase extends UidCardinalityEstimator {
 
 }
 
-case class MaxLeaseIdUidCardinalityEstimator(maxLeaseId: Long) extends UidCardinalityEstimatorBase {
+case class MaxLeaseIdUidCardinalityEstimator(maxLeaseId: Option[Long]) extends UidCardinalityEstimatorBase {
 
-  if (maxLeaseId <= 0)
+  if (maxLeaseId.exists(_ <= 0))
     throw new IllegalArgumentException(s"uidCardinality must be larger than zero: $maxLeaseId")
 
   /**
@@ -61,11 +61,11 @@ case class MaxLeaseIdUidCardinalityEstimator(maxLeaseId: Long) extends UidCardin
    * @return estimated number of uids or None
    */
   override def uidCardinality(partition: Partition): Option[Long] =
-    super.uidCardinality(partition).orElse(Some(maxLeaseId))
+    super.uidCardinality(partition).orElse(maxLeaseId)
 
 }
 
 object UidCardinalityEstimator {
-  def forMaxLeaseId(maxLeaseId: Long): UidCardinalityEstimator =
+  def forMaxLeaseId(maxLeaseId: Option[Long]): UidCardinalityEstimator =
     MaxLeaseIdUidCardinalityEstimator(maxLeaseId)
 }

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/UidCardinalityEstimator.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/UidCardinalityEstimator.scala
@@ -27,7 +27,7 @@ trait UidCardinalityEstimator {
    * @param partition a partition
    * @return estimated number of uids or None
    */
-  def uidCardinality(partition: Partition): Option[Long]
+  def uidCardinality(partition: Partition): Option[BigInt]
 
 }
 
@@ -43,12 +43,12 @@ abstract class UidCardinalityEstimatorBase extends UidCardinalityEstimator {
    * @param partition a partition
    * @return estimated number of uids or None
    */
-  override def uidCardinality(partition: Partition): Option[Long] =
-    partition.uidRange.map(_.length).orElse(partition.uids.map(_.size))
+  override def uidCardinality(partition: Partition): Option[BigInt] =
+    partition.uidRange.map(_.length).map(BigInt.apply).orElse(partition.uids.map(_.size))
 
 }
 
-case class MaxLeaseIdUidCardinalityEstimator(maxLeaseId: Option[Long]) extends UidCardinalityEstimatorBase {
+case class MaxLeaseIdUidCardinalityEstimator(maxLeaseId: Option[BigInt]) extends UidCardinalityEstimatorBase {
 
   if (maxLeaseId.exists(_ <= 0))
     throw new IllegalArgumentException(s"uidCardinality must be larger than zero: $maxLeaseId")
@@ -60,12 +60,12 @@ case class MaxLeaseIdUidCardinalityEstimator(maxLeaseId: Option[Long]) extends U
    * @param partition a partition
    * @return estimated number of uids or None
    */
-  override def uidCardinality(partition: Partition): Option[Long] =
+  override def uidCardinality(partition: Partition): Option[BigInt] =
     super.uidCardinality(partition).orElse(maxLeaseId)
 
 }
 
 object UidCardinalityEstimator {
-  def forMaxLeaseId(maxLeaseId: Option[Long]): UidCardinalityEstimator =
+  def forMaxLeaseId(maxLeaseId: Option[BigInt]): UidCardinalityEstimator =
     MaxLeaseIdUidCardinalityEstimator(maxLeaseId)
 }

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestClusterState.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestClusterState.scala
@@ -143,7 +143,7 @@ class TestClusterState extends AnyFunSpec {
         "1" -> Set("dgraph.graphql.schema", "dgraph.graphql.xid", "dgraph.type", "director"),
         "2" -> Set("name", "release_date", "revenue")
       ))
-      assert(state.maxLeaseId === 10000)
+      assert(state.maxLeaseId === Some(10000))
       assert(state.cid === UUID.fromString("5aacce50-a95f-440b-a32e-fbe6b4003980"))
     }
 
@@ -292,7 +292,7 @@ class TestClusterState extends AnyFunSpec {
         "1" -> Set("dgraph.graphql.schema", "dgraph.type"),
         "2" -> Set("director", "name")
       ))
-      assert(state.maxLeaseId === 10000)
+      assert(state.maxLeaseId === Some(10000))
       assert(state.cid === UUID.fromString("350fd4f5-771d-4021-8ef9-cd1b79aa6ea0"))
     }
 
@@ -441,7 +441,7 @@ class TestClusterState extends AnyFunSpec {
         "1" -> Set("dgraph.graphql.schema", "dgraph.type"),
         "2" -> Set("director")  // predicate name is ignored as it is not in the default namespace
       ))
-      assert(state.maxLeaseId === 10000)
+      assert(state.maxLeaseId === Some(10000))
       assert(state.cid === UUID.fromString("350fd4f5-771d-4021-8ef9-cd1b79aa6ea0"))
     }
   }

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestClusterStateProvider.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestClusterStateProvider.scala
@@ -37,7 +37,7 @@ class TestClusterStateProvider extends AnyFunSpec with DgraphTestCluster {
       val actualPredicates = state.get.groupPredicates("1")
       val expectedPredicates = Set("name", "title", "starring", "running_time", "release_date", "director", "revenue", "dgraph.type")
       assert(expectedPredicates.diff(actualPredicates) === Set.empty)
-      assert(state.get.maxLeaseId === 10000)
+      assert(state.get.maxLeaseId === Some(10000))
     }
 
     it("should retrieve cluster states") {
@@ -48,7 +48,7 @@ class TestClusterStateProvider extends AnyFunSpec with DgraphTestCluster {
       val actualPredicates = state.groupPredicates("1")
       val expectedPredicates = Set("name", "title", "starring", "running_time", "release_date", "director", "revenue", "dgraph.type")
       assert(actualPredicates === expectedPredicates)
-      assert(state.maxLeaseId === 10000)
+      assert(state.maxLeaseId === Some(10000))
     }
 
     it("should fail for unavailable cluster") {

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestClusterStateProvider.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestClusterStateProvider.scala
@@ -16,6 +16,7 @@
 
 package uk.co.gresearch.spark.dgraph.connector
 
+import com.google.common.primitives.UnsignedLong
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.scalatest.funspec.AnyFunSpec
 import uk.co.gresearch.spark.dgraph.DgraphTestCluster
@@ -37,7 +38,7 @@ class TestClusterStateProvider extends AnyFunSpec with DgraphTestCluster {
       val actualPredicates = state.get.groupPredicates("1")
       val expectedPredicates = Set("name", "title", "starring", "running_time", "release_date", "director", "revenue", "dgraph.type")
       assert(expectedPredicates.diff(actualPredicates) === Set.empty)
-      assert(state.get.maxLeaseId === Some(10000))
+      assert(state.get.maxLeaseId.map(_.intValue()) === Some(10000))
     }
 
     it("should retrieve cluster states") {
@@ -48,7 +49,7 @@ class TestClusterStateProvider extends AnyFunSpec with DgraphTestCluster {
       val actualPredicates = state.groupPredicates("1")
       val expectedPredicates = Set("name", "title", "starring", "running_time", "release_date", "director", "revenue", "dgraph.type")
       assert(actualPredicates === expectedPredicates)
-      assert(state.maxLeaseId === Some(10000))
+      assert(state.maxLeaseId.map(_.intValue()) === Some(10000))
     }
 
     it("should fail for unavailable cluster") {

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestAlphaPartitioner.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestAlphaPartitioner.scala
@@ -39,7 +39,7 @@ class TestAlphaPartitioner extends AnyFunSpec {
         "3" -> Set("pred5"),
         "4" -> Set("pred6", "pred7")
       ),
-      10000,
+      Some(10000),
       UUID.randomUUID()
     )
 

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestAlphaPartitioner.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestAlphaPartitioner.scala
@@ -16,6 +16,7 @@
 
 package uk.co.gresearch.spark.dgraph.connector.partitioner
 
+import com.google.common.primitives.UnsignedLong
 import org.scalatest.funspec.AnyFunSpec
 import uk.co.gresearch.spark.dgraph.connector._
 
@@ -39,7 +40,7 @@ class TestAlphaPartitioner extends AnyFunSpec {
         "3" -> Set("pred5"),
         "4" -> Set("pred6", "pred7")
       ),
-      Some(10000),
+      Some(UnsignedLong.valueOf(10000)),
       UUID.randomUUID()
     )
 

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestDefaultPartitionerOption.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestDefaultPartitionerOption.scala
@@ -16,6 +16,7 @@
 
 package uk.co.gresearch.spark.dgraph.connector.partitioner
 
+import com.google.common.primitives.UnsignedLong
 import io.dgraph.DgraphProto.TxnContext
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.scalatest.funspec.AnyFunSpec
@@ -31,7 +32,7 @@ class TestDefaultPartitionerOption extends AnyFunSpec {
     val state = ClusterState(
       Map("1" -> Set(target)),
       Map("1" -> schema.predicates.map(_.predicateName)),
-      Some(10000),
+      Some(UnsignedLong.valueOf(10000)),
       UUID.randomUUID()
     )
     val transaction = Some(Transaction(TxnContext.newBuilder().build()))

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestDefaultPartitionerOption.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestDefaultPartitionerOption.scala
@@ -31,7 +31,7 @@ class TestDefaultPartitionerOption extends AnyFunSpec {
     val state = ClusterState(
       Map("1" -> Set(target)),
       Map("1" -> schema.predicates.map(_.predicateName)),
-      10000,
+      Some(10000),
       UUID.randomUUID()
     )
     val transaction = Some(Transaction(TxnContext.newBuilder().build()))

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestGroupPartitioner.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestGroupPartitioner.scala
@@ -37,7 +37,7 @@ class TestGroupPartitioner extends AnyFunSpec {
         "2" -> Set("pred1", "pred2", "pred3"),
         "3" -> Set("pred4")
       ),
-      10000,
+      Some(10000),
       UUID.randomUUID()
     )
 

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestGroupPartitioner.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestGroupPartitioner.scala
@@ -16,6 +16,7 @@
 
 package uk.co.gresearch.spark.dgraph.connector.partitioner
 
+import com.google.common.primitives.UnsignedLong
 import org.scalatest.funspec.AnyFunSpec
 import uk.co.gresearch.spark.dgraph.connector._
 
@@ -37,7 +38,7 @@ class TestGroupPartitioner extends AnyFunSpec {
         "2" -> Set("pred1", "pred2", "pred3"),
         "3" -> Set("pred4")
       ),
-      Some(10000),
+      Some(UnsignedLong.valueOf(10000)),
       UUID.randomUUID()
     )
 

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestPartitionerProvider.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestPartitionerProvider.scala
@@ -16,6 +16,7 @@
 
 package uk.co.gresearch.spark.dgraph.connector.partitioner
 
+import com.google.common.primitives.UnsignedLong
 import io.dgraph.DgraphProto.TxnContext
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.scalatest.funspec.AnyFunSpec
@@ -31,7 +32,7 @@ class TestPartitionerProvider extends AnyFunSpec {
   val state: ClusterState = ClusterState(
     Map("1" -> target.toSet),
     Map("1" -> schema.predicates.map(_.predicateName)),
-    Some(10000),
+    Some(UnsignedLong.valueOf(10000)),
     UUID.randomUUID()
   )
   val transaction: Option[Transaction] = Some(Transaction(TxnContext.newBuilder().build()))

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestPartitionerProvider.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestPartitionerProvider.scala
@@ -31,7 +31,7 @@ class TestPartitionerProvider extends AnyFunSpec {
   val state: ClusterState = ClusterState(
     Map("1" -> target.toSet),
     Map("1" -> schema.predicates.map(_.predicateName)),
-    10000,
+    Some(10000),
     UUID.randomUUID()
   )
   val transaction: Option[Transaction] = Some(Transaction(TxnContext.newBuilder().build()))

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestPartitionerProvider.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestPartitionerProvider.scala
@@ -44,7 +44,7 @@ class TestPartitionerProvider extends AnyFunSpec {
     val group = GroupPartitioner(schema, state)
     val alpha = AlphaPartitioner(schema, state, AlphaPartitionerPartitionsDefault)
     val pred = PredicatePartitioner(schema, state, PredicatePartitionerPredicatesDefault)
-    val uidRange = UidRangePartitioner(singleton, UidRangePartitionerUidsPerPartDefault, maxLeaseEstimator)
+    val uidRange = UidRangePartitioner(singleton, UidRangePartitionerUidsPerPartDefault, UidRangePartitionerMaxPartsDefault, maxLeaseEstimator)
 
     Seq(
       ("singleton", singleton),
@@ -74,7 +74,7 @@ class TestPartitionerProvider extends AnyFunSpec {
       val partitioner = provider.getPartitioner(schema, state, transaction, options)
 
       val predicatePart = PredicatePartitioner(schema, state, PredicatePartitionerPredicatesDefault)
-      val expected = UidRangePartitioner(predicatePart, UidRangePartitionerUidsPerPartDefault, maxLeaseEstimator)
+      val expected = UidRangePartitioner(predicatePart, UidRangePartitionerUidsPerPartDefault, UidRangePartitionerMaxPartsDefault, maxLeaseEstimator)
       assert(partitioner === expected)
     }
 
@@ -84,13 +84,14 @@ class TestPartitionerProvider extends AnyFunSpec {
         Map(
           PredicatePartitionerPredicatesOption -> "1",
           UidRangePartitionerUidsPerPartOption -> "2",
+          UidRangePartitionerMaxPartsOption -> "3",
           UidRangePartitionerEstimatorOption -> MaxLeaseIdEstimatorOption
         ).asJava
       )
       val partitioner = provider.getPartitioner(schema, state, transaction, options)
 
       val predicatePart = PredicatePartitioner(schema, state, 1)
-      val expected = UidRangePartitioner(predicatePart, 2, MaxLeaseIdUidCardinalityEstimator(state.maxLeaseId))
+      val expected = UidRangePartitioner(predicatePart, 2, 3, MaxLeaseIdUidCardinalityEstimator(state.maxLeaseId))
       assert(partitioner === expected)
     }
 

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestPredicatePartitioner.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestPredicatePartitioner.scala
@@ -71,13 +71,13 @@ class TestPredicatePartitioner extends AnyFunSpec {
         "3" -> Set("pred4", "pred5"),
         "4" -> Set("pred6")
       ),
-      10000,
+      Some(10000),
       UUID.randomUUID()
     )
     val simpleClusterState = ClusterState(
       Map("1" -> Set(Target("host1:9080"), Target("host2:9080"), Target("host3:9080"))),
       Map("1" -> Set("pred1", "pred2", "pred3", "pred4", "pred5", "pred6")),
-      10000,
+      Some(10000),
       UUID.randomUUID()
     )
 

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestPredicatePartitioner.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestPredicatePartitioner.scala
@@ -16,6 +16,7 @@
 
 package uk.co.gresearch.spark.dgraph.connector.partitioner
 
+import com.google.common.primitives.UnsignedLong
 import org.scalatest.funspec.AnyFunSpec
 import uk.co.gresearch.spark.dgraph.connector._
 
@@ -71,13 +72,13 @@ class TestPredicatePartitioner extends AnyFunSpec {
         "3" -> Set("pred4", "pred5"),
         "4" -> Set("pred6")
       ),
-      Some(10000),
+      Some(UnsignedLong.valueOf(10000)),
       UUID.randomUUID()
     )
     val simpleClusterState = ClusterState(
       Map("1" -> Set(Target("host1:9080"), Target("host2:9080"), Target("host3:9080"))),
       Map("1" -> Set("pred1", "pred2", "pred3", "pred4", "pred5", "pred6")),
-      Some(10000),
+      Some(UnsignedLong.valueOf(10000)),
       UUID.randomUUID()
     )
 

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestUidCardinalityEstimator.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestUidCardinalityEstimator.scala
@@ -53,15 +53,15 @@ class TestUidCardinalityEstimator extends AnyFunSpec {
   }
 
   describe("MaxLeaseIdUidCardinalityEstimator") {
-    val estimator = MaxLeaseIdUidCardinalityEstimator(1234)
+    val estimator = MaxLeaseIdUidCardinalityEstimator(Some(1234))
     doTestUidCardinalityEstimatorBase(estimator, Some(1234))
 
     it("should fail on negative or zero max uids") {
       assertThrows[IllegalArgumentException] {
-        UidCardinalityEstimator.forMaxLeaseId(-1)
+        UidCardinalityEstimator.forMaxLeaseId(Some(-1))
       }
       assertThrows[IllegalArgumentException] {
-        UidCardinalityEstimator.forMaxLeaseId(0)
+        UidCardinalityEstimator.forMaxLeaseId(Some(0))
       }
     }
 

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestUidCardinalityEstimator.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestUidCardinalityEstimator.scala
@@ -16,6 +16,7 @@
 
 package uk.co.gresearch.spark.dgraph.connector.partitioner
 
+import com.google.common.primitives.UnsignedLong
 import org.scalatest.funspec.AnyFunSpec
 import uk.co.gresearch.spark.dgraph.connector._
 
@@ -29,7 +30,7 @@ class TestUidCardinalityEstimator extends AnyFunSpec {
       val partition = Partition(Seq.empty, Set(range))
       val actual = estimator.uidCardinality(partition)
       assert(actual.isDefined === true)
-      assert(actual.get === range.length)
+      assert(actual.get.intValue() === range.length)
     }
 
     it("should estimate partition's uids cardinality") {
@@ -37,13 +38,13 @@ class TestUidCardinalityEstimator extends AnyFunSpec {
       val partition = Partition(Seq.empty, Set(uids))
       val actual = estimator.uidCardinality(partition)
       assert(actual.isDefined === true)
-      assert(actual.get === uids.uids.size)
+      assert(actual.get.intValue() === uids.uids.size)
     }
 
     it("should estimate partition without uid range and uids") {
       val partition = Partition(Seq.empty)
       val actual = estimator.uidCardinality(partition)
-      assert(actual === expectedEstimationWithoutRange)
+      assert(actual.map(_.intValue()) === expectedEstimationWithoutRange)
     }
 
   }
@@ -54,7 +55,7 @@ class TestUidCardinalityEstimator extends AnyFunSpec {
 
   describe("MaxLeaseIdUidCardinalityEstimator") {
     describe("with some maxLeaseId") {
-      doTestUidCardinalityEstimatorBase(MaxLeaseIdUidCardinalityEstimator(Some(1234)), Some(1234))
+      doTestUidCardinalityEstimatorBase(MaxLeaseIdUidCardinalityEstimator(Some(UnsignedLong.valueOf(1234))), Some(1234))
     }
     describe("with no maxLeaseId") {
       doTestUidCardinalityEstimatorBase(MaxLeaseIdUidCardinalityEstimator(None), None)
@@ -62,10 +63,10 @@ class TestUidCardinalityEstimator extends AnyFunSpec {
 
     it("should fail on negative or zero max uids") {
       assertThrows[IllegalArgumentException] {
-        UidCardinalityEstimator.forMaxLeaseId(Some(-1))
+        UidCardinalityEstimator.forMaxLeaseId(Some(UnsignedLong.valueOf(-1)))
       }
       assertThrows[IllegalArgumentException] {
-        UidCardinalityEstimator.forMaxLeaseId(Some(0))
+        UidCardinalityEstimator.forMaxLeaseId(Some(UnsignedLong.valueOf(0)))
       }
     }
 

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestUidCardinalityEstimator.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestUidCardinalityEstimator.scala
@@ -53,8 +53,12 @@ class TestUidCardinalityEstimator extends AnyFunSpec {
   }
 
   describe("MaxLeaseIdUidCardinalityEstimator") {
-    val estimator = MaxLeaseIdUidCardinalityEstimator(Some(1234))
-    doTestUidCardinalityEstimatorBase(estimator, Some(1234))
+    describe("with some maxLeaseId") {
+      doTestUidCardinalityEstimatorBase(MaxLeaseIdUidCardinalityEstimator(Some(1234)), Some(1234))
+    }
+    describe("with no maxLeaseId") {
+      doTestUidCardinalityEstimatorBase(MaxLeaseIdUidCardinalityEstimator(None), None)
+    }
 
     it("should fail on negative or zero max uids") {
       assertThrows[IllegalArgumentException] {

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestUidRangePartitioner.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestUidRangePartitioner.scala
@@ -102,6 +102,24 @@ class TestUidRangePartitioner extends AnyFunSpec {
       }
     }
 
+    it("should fail on negative uidsPerPartition") {
+      assertThrows[IllegalArgumentException] {
+        UidRangePartitioner(singleton, -1, 2, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
+      }
+    }
+
+    it("should fail on zero maxPartitions") {
+      assertThrows[IllegalArgumentException] {
+        UidRangePartitioner(singleton, 1, 0, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
+      }
+    }
+
+    it("should fail on negative maxPartitions") {
+      assertThrows[IllegalArgumentException] {
+        UidRangePartitioner(singleton, 1, -1, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
+      }
+    }
+
     it("should not partition into more than max partitions") {
       val uidPartitioner1 = UidRangePartitioner(singleton, 100, 5, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
       assert(uidPartitioner1.getPartitions === singleton.getPartitions)

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestUidRangePartitioner.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestUidRangePartitioner.scala
@@ -59,7 +59,7 @@ class TestUidRangePartitioner extends AnyFunSpec {
       testSizes.foreach { size =>
 
         it(s"should decorate $label partitioner with ${size} uids per partition") {
-          val uidPartitioner = UidRangePartitioner(partitioner, size, UidCardinalityEstimator.forMaxLeaseId(clusterState.maxLeaseId))
+          val uidPartitioner = UidRangePartitioner(partitioner, size, UidRangePartitionerMaxPartsDefault, UidCardinalityEstimator.forMaxLeaseId(clusterState.maxLeaseId))
           val partitions = partitioner.getPartitions
           val uidPartitions = uidPartitioner.getPartitions
 
@@ -81,7 +81,7 @@ class TestUidRangePartitioner extends AnyFunSpec {
     testPartitioners.foreach{ case (partitioner, label) =>
 
       it(s"should noop $label partitioner with too large uidsPerPartition") {
-        val uidPartitioner = UidRangePartitioner(partitioner, clusterState.maxLeaseId.get.toInt, UidCardinalityEstimator.forMaxLeaseId(clusterState.maxLeaseId))
+        val uidPartitioner = UidRangePartitioner(partitioner, clusterState.maxLeaseId.get.toInt, 10, UidCardinalityEstimator.forMaxLeaseId(clusterState.maxLeaseId))
         assert(uidPartitioner.getPartitions === partitioner.getPartitions)
       }
 
@@ -89,26 +89,29 @@ class TestUidRangePartitioner extends AnyFunSpec {
 
     it("should fail on null partitioner") {
       assertThrows[IllegalArgumentException] {
-        UidRangePartitioner(null, 1, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
-      }
-    }
-
-    it("should fail with integer overflow partition size") {
-      assertThrows[IllegalArgumentException] {
-        UidRangePartitioner(singleton, 1, UidCardinalityEstimator.forMaxLeaseId(Some(Long.MaxValue))).getPartitions
+        UidRangePartitioner(null, 1, 2, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
       }
     }
 
     it("should fail on decorating uid partitioner") {
-      val uidPartitioner = UidRangePartitioner(singleton, 2, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
+      // with too low maxPartitions, this partitioner does mot range-partition the singleton partitioner
+      // and the assertion will not pass, see test "should not partition into more than max partitions"
+      val uidPartitioner = UidRangePartitioner(singleton, 100, 10, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
       assertThrows[IllegalArgumentException] {
-        UidRangePartitioner(uidPartitioner, 1, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
+        UidRangePartitioner(uidPartitioner, 1, 2, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
       }
+    }
+
+    it("should not partition into more than max partitions") {
+      val uidPartitioner1 = UidRangePartitioner(singleton, 100, 5, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
+      assert(uidPartitioner1.getPartitions === singleton.getPartitions)
+      val uidPartitioner2 = UidRangePartitioner(singleton, 100, 10, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
+      assert(uidPartitioner2.getPartitions !== singleton.getPartitions)
     }
 
     it("should support what decorated partitioner supports") {
       val partitioner = PredicatePartitioner(schema, clusterState, 1)
-      val uidPartitioner = UidRangePartitioner(partitioner, 2, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
+      val uidPartitioner = UidRangePartitioner(partitioner, 2, 3, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
 
       Seq[Set[Filter]](
         Set(SubjectIsIn(Uid("0x1"))),
@@ -130,7 +133,7 @@ class TestUidRangePartitioner extends AnyFunSpec {
 
     it("should forward filters to decorated partitioner") {
       val partitioner = PredicatePartitioner(schema, clusterState, 1)
-      val uidPartitioner = UidRangePartitioner(partitioner, 2, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
+      val uidPartitioner = UidRangePartitioner(partitioner, 2, 3, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
       // deliberately not EmptyFilters here to test with our own instance
       val filters = Filters(Set.empty, Set.empty)
       val actual =
@@ -142,7 +145,7 @@ class TestUidRangePartitioner extends AnyFunSpec {
 
     it("should forward projection to decorated partitioner") {
       val partitioner = PredicatePartitioner(schema, clusterState, 1)
-      val uidPartitioner = UidRangePartitioner(partitioner, 2, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
+      val uidPartitioner = UidRangePartitioner(partitioner, 2, 3, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
       val projection = schema.predicates.toSeq
       val actual =
         uidPartitioner.withProjection(projection)
@@ -156,7 +159,7 @@ class TestUidRangePartitioner extends AnyFunSpec {
       val langPreds = Set("pred2")
       val langSchema = Schema(schema.predicates.map(p => if (langPreds.contains(p.predicateName)) p.copy(isLang = true) else p))
       val partitioner = PredicatePartitioner(langSchema, clusterState, 5)
-      val uidPartitioner = UidRangePartitioner(partitioner, 500, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
+      val uidPartitioner = UidRangePartitioner(partitioner, 500, 10, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
       val partitions = uidPartitioner.getPartitions
       assert(partitions === Seq(
         Partition(Seq(Target("host1:9080"), Target("host2:9080"))).has(Set("pred1"), Set.empty).range(1, 501).getAll,

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestUidRangePartitioner.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestUidRangePartitioner.scala
@@ -16,6 +16,7 @@
 
 package uk.co.gresearch.spark.dgraph.connector.partitioner
 
+import com.google.common.primitives.UnsignedLong
 import org.scalatest.funspec.AnyFunSpec
 import uk.co.gresearch.spark.dgraph.connector
 import uk.co.gresearch.spark.dgraph.connector._
@@ -36,7 +37,7 @@ class TestUidRangePartitioner extends AnyFunSpec {
         "1" -> Set("pred1"),
         "2" -> Set("pred2")
       ),
-      Some(10000),
+      Some(UnsignedLong.valueOf(10000)),
       UUID.randomUUID()
     )
 
@@ -81,7 +82,7 @@ class TestUidRangePartitioner extends AnyFunSpec {
     testPartitioners.foreach{ case (partitioner, label) =>
 
       it(s"should noop $label partitioner with too large uidsPerPartition") {
-        val uidPartitioner = UidRangePartitioner(partitioner, clusterState.maxLeaseId.get.toInt, 10, UidCardinalityEstimator.forMaxLeaseId(clusterState.maxLeaseId))
+        val uidPartitioner = UidRangePartitioner(partitioner, clusterState.maxLeaseId.get.intValue(), 10, UidCardinalityEstimator.forMaxLeaseId(clusterState.maxLeaseId))
         assert(uidPartitioner.getPartitions === partitioner.getPartitions)
       }
 
@@ -89,47 +90,47 @@ class TestUidRangePartitioner extends AnyFunSpec {
 
     it("should fail on null partitioner") {
       assertThrows[IllegalArgumentException] {
-        UidRangePartitioner(null, 1, 2, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
+        UidRangePartitioner(null, 1, 2, UidCardinalityEstimator.forMaxLeaseId(Some(UnsignedLong.valueOf(1000))))
       }
     }
 
     it("should fail on decorating uid partitioner") {
       // with too low maxPartitions, this partitioner does mot range-partition the singleton partitioner
       // and the assertion will not pass, see test "should not partition into more than max partitions"
-      val uidPartitioner = UidRangePartitioner(singleton, 100, 10, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
+      val uidPartitioner = UidRangePartitioner(singleton, 100, 10, UidCardinalityEstimator.forMaxLeaseId(Some(UnsignedLong.valueOf(1000))))
       assertThrows[IllegalArgumentException] {
-        UidRangePartitioner(uidPartitioner, 1, 2, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
+        UidRangePartitioner(uidPartitioner, 1, 2, UidCardinalityEstimator.forMaxLeaseId(Some(UnsignedLong.valueOf(1000))))
       }
     }
 
     it("should fail on negative uidsPerPartition") {
       assertThrows[IllegalArgumentException] {
-        UidRangePartitioner(singleton, -1, 2, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
+        UidRangePartitioner(singleton, -1, 2, UidCardinalityEstimator.forMaxLeaseId(Some(UnsignedLong.valueOf(1000))))
       }
     }
 
     it("should fail on zero maxPartitions") {
       assertThrows[IllegalArgumentException] {
-        UidRangePartitioner(singleton, 1, 0, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
+        UidRangePartitioner(singleton, 1, 0, UidCardinalityEstimator.forMaxLeaseId(Some(UnsignedLong.valueOf(1000))))
       }
     }
 
     it("should fail on negative maxPartitions") {
       assertThrows[IllegalArgumentException] {
-        UidRangePartitioner(singleton, 1, -1, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
+        UidRangePartitioner(singleton, 1, -1, UidCardinalityEstimator.forMaxLeaseId(Some(UnsignedLong.valueOf(1000))))
       }
     }
 
     it("should not partition into more than max partitions") {
-      val uidPartitioner1 = UidRangePartitioner(singleton, 100, 5, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
+      val uidPartitioner1 = UidRangePartitioner(singleton, 100, 5, UidCardinalityEstimator.forMaxLeaseId(Some(UnsignedLong.valueOf(1000))))
       assert(uidPartitioner1.getPartitions === singleton.getPartitions)
-      val uidPartitioner2 = UidRangePartitioner(singleton, 100, 10, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
+      val uidPartitioner2 = UidRangePartitioner(singleton, 100, 10, UidCardinalityEstimator.forMaxLeaseId(Some(UnsignedLong.valueOf(1000))))
       assert(uidPartitioner2.getPartitions !== singleton.getPartitions)
     }
 
     it("should support what decorated partitioner supports") {
       val partitioner = PredicatePartitioner(schema, clusterState, 1)
-      val uidPartitioner = UidRangePartitioner(partitioner, 2, 3, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
+      val uidPartitioner = UidRangePartitioner(partitioner, 2, 3, UidCardinalityEstimator.forMaxLeaseId(Some(UnsignedLong.valueOf(1000))))
 
       Seq[Set[Filter]](
         Set(SubjectIsIn(Uid("0x1"))),
@@ -151,7 +152,7 @@ class TestUidRangePartitioner extends AnyFunSpec {
 
     it("should forward filters to decorated partitioner") {
       val partitioner = PredicatePartitioner(schema, clusterState, 1)
-      val uidPartitioner = UidRangePartitioner(partitioner, 2, 3, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
+      val uidPartitioner = UidRangePartitioner(partitioner, 2, 3, UidCardinalityEstimator.forMaxLeaseId(Some(UnsignedLong.valueOf(1000))))
       // deliberately not EmptyFilters here to test with our own instance
       val filters = Filters(Set.empty, Set.empty)
       val actual =
@@ -163,7 +164,7 @@ class TestUidRangePartitioner extends AnyFunSpec {
 
     it("should forward projection to decorated partitioner") {
       val partitioner = PredicatePartitioner(schema, clusterState, 1)
-      val uidPartitioner = UidRangePartitioner(partitioner, 2, 3, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
+      val uidPartitioner = UidRangePartitioner(partitioner, 2, 3, UidCardinalityEstimator.forMaxLeaseId(Some(UnsignedLong.valueOf(1000))))
       val projection = schema.predicates.toSeq
       val actual =
         uidPartitioner.withProjection(projection)
@@ -177,7 +178,7 @@ class TestUidRangePartitioner extends AnyFunSpec {
       val langPreds = Set("pred2")
       val langSchema = Schema(schema.predicates.map(p => if (langPreds.contains(p.predicateName)) p.copy(isLang = true) else p))
       val partitioner = PredicatePartitioner(langSchema, clusterState, 5)
-      val uidPartitioner = UidRangePartitioner(partitioner, 500, 10, UidCardinalityEstimator.forMaxLeaseId(Some(1000)))
+      val uidPartitioner = UidRangePartitioner(partitioner, 500, 10, UidCardinalityEstimator.forMaxLeaseId(Some(UnsignedLong.valueOf(1000))))
       val partitions = uidPartitioner.getPartitions
       assert(partitions === Seq(
         Partition(Seq(Target("host1:9080"), Target("host2:9080"))).has(Set("pred1"), Set.empty).range(1, 501).getAll,


### PR DESCRIPTION
Fixes #215 in the sense that no exception is thrown and data can be read from Dgraph. However, partitioning will be limited to predicate partitioning, which is poor.

This supports maxLeaseId / maxUID that exceeds `Long`, as well as values that cannot be parsed into numeric value.