### PR TITLE
Prepare main branch for becoming default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - 'spark-*'
+      - 'main'
     tags:
       - '*'
   pull_request:


### PR DESCRIPTION
Preparation to make `main` branch the default branch and deprecate `spark-*` branches.