### PR TITLE
Add back limited support for Spark<3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
             scala-compat-version: '2.12'
             scala-version: '2.12.10'
             dgraph-minor-version: "22.0"
-            dgraph-version: "22.00.2"
+            dgraph-version: "22.0.2"
             hadoop-version: '2.7'
 
           - spark-compat-version: '3.1'
@@ -237,7 +237,7 @@ jobs:
             scala-compat-version: '2.12'
             scala-version: '2.12.10'
             dgraph-minor-version: "22.0"
-            dgraph-version: "22.00.2"
+            dgraph-version: "22.0.2"
             hadoop-version: '2.7'
 
           - spark-compat-version: '3.2'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - spark-compat-version: '3.0'
+            spark-version: '3.0.3'
+            scala-compat-version: '2.12'
+            scala-version: '2.12.10'
+
+          - spark-compat-version: '3.1'
+            spark-version: '3.1.3'
+            scala-compat-version: '2.12'
+            scala-version: '2.12.10'
+
           - spark-compat-version: '3.2'
             spark-version: '3.2.4'
             scala-compat-version: '2.12'
@@ -91,12 +101,24 @@ jobs:
       matrix:
         # main spark versions tested in test-dgraph, not testes here again
         spark-version: [
+            "3.0.3",
+            "3.1.3",
             "3.2.0", "3.2.1", "3.2.2", "3.2.3", "3.2.4",
             "3.3.0", "3.3.1", "3.3.2"
         ]
         dgraph-minor-version: ["21.12", "22.0", "23.0"]
         scala-compat-version: ["2.12"]
         include:
+          - spark-version: "3.0.3"
+            spark-compat-version: "3.0"
+            scala-compat-version: "2.12"
+            scala-version: "2.12.10"
+
+          - spark-version: "3.1.3"
+            spark-compat-version: "3.1"
+            scala-compat-version: "2.12"
+            scala-version: "2.12.10"
+
           - spark-version: "3.2.0"
             spark-compat-version: "3.2"
             scala-compat-version: "2.12"
@@ -202,6 +224,22 @@ jobs:
         dgraph-minor-version: ["20.03", "20.07", "20.11", "21.12", "22.0", "23.0"]
         scala-compat-version: ["2.12"]
         include:
+          - spark-compat-version: '3.0'
+            spark-version: '3.0.3'
+            scala-compat-version: '2.12'
+            scala-version: '2.12.10'
+            dgraph-minor-version: "22.0"
+            dgraph-version: "22.00.2"
+            hadoop-version: '2.7'
+
+          - spark-compat-version: '3.1'
+            spark-version: '3.1.3'
+            scala-compat-version: '2.12'
+            scala-version: '2.12.10'
+            dgraph-minor-version: "22.0"
+            dgraph-version: "22.00.2"
+            hadoop-version: '2.7'
+
           - spark-compat-version: '3.2'
             spark-version: '3.2.4'
             scala-compat-version: '2.12'

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -42,6 +42,8 @@ Once you have released the new version, release from the same tag for all other 
 
 |Spark|Scala|
 |:----|:----|
+|3.0  |2.12.10|
+|3.1  |2.12.10|
 |3.2  |2.12.15|
 |3.3  |2.12.15|
 |3.4  |2.12.17|

--- a/examples/scala/src/test/resources/log4j.properties
+++ b/examples/scala/src/test/resources/log4j.properties
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set everything to be logged to the console
+log4j.rootCategory=WARN, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+
+# Set the default spark-shell log level to WARN. When running the spark-shell, the
+# log level for this class is used to overwrite the root logger's log level, so that
+# the user can have different defaults for the shell and regular Spark apps.
+log4j.logger.org.apache.spark.repl.Main=WARN
+
+# Settings to quiet third party logs that are too verbose
+log4j.logger.org.sparkproject.jetty=WARN
+log4j.logger.org.sparkproject.jetty.util.component.AbstractLifeCycle=ERROR
+log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
+log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO
+log4j.logger.org.apache.parquet=ERROR
+log4j.logger.parquet=ERROR
+
+# SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs in SparkSQL with Hive support
+log4j.logger.org.apache.hadoop.hive.metastore.RetryingHMSHandler=FATAL
+log4j.logger.org.apache.hadoop.hive.ql.exec.FunctionRegistry=ERROR
+
+# Set Spark Dgraph Connector logging to DEBUG
+log4j.logger.uk.co.gresearch.spark.dgraph=WARN
+

--- a/python/requirements-3.0.txt
+++ b/python/requirements-3.0.txt
@@ -1,0 +1,2 @@
+py4j
+pyspark==3.0.0

--- a/python/requirements-3.1.txt
+++ b/python/requirements-3.1.txt
@@ -1,0 +1,2 @@
+py4j
+pyspark==3.1.0

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set everything to be logged to the console
+log4j.rootCategory=WARN, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+
+# Set the default spark-shell log level to WARN. When running the spark-shell, the
+# log level for this class is used to overwrite the root logger's log level, so that
+# the user can have different defaults for the shell and regular Spark apps.
+log4j.logger.org.apache.spark.repl.Main=WARN
+
+# Settings to quiet third party logs that are too verbose
+log4j.logger.org.sparkproject.jetty=WARN
+log4j.logger.org.sparkproject.jetty.util.component.AbstractLifeCycle=ERROR
+log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
+log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO
+log4j.logger.org.apache.parquet=ERROR
+log4j.logger.parquet=ERROR
+
+# SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs in SparkSQL with Hive support
+log4j.logger.org.apache.hadoop.hive.metastore.RetryingHMSHandler=FATAL
+log4j.logger.org.apache.hadoop.hive.ql.exec.FunctionRegistry=ERROR
+
+# Set Spark Dgraph Connector logging to DEBUG
+log4j.logger.uk.co.gresearch.spark.dgraph=WARN
+

--- a/src/test/scala-spark-3.0/uk/co/gresearch/spark/package.scala
+++ b/src/test/scala-spark-3.0/uk/co/gresearch/spark/package.scala
@@ -1,0 +1,1 @@
+../../../../../scala-spark-3.2/uk/co/gresearch/spark/package.scala

--- a/src/test/scala-spark-3.1/uk/co/gresearch/spark/package.scala
+++ b/src/test/scala-spark-3.1/uk/co/gresearch/spark/package.scala
@@ -1,0 +1,1 @@
+../../../../../scala-spark-3.2/uk/co/gresearch/spark/package.scala


### PR DESCRIPTION
Adds back limited support (in CI) for Spark 3.0 and 3.1. It is still worth releasing for these version though they are EOL because the are still used.