### PR TITLE
Rename maxLeaseId to maxUid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [UNRELEASED] - YYYY-MM-DD
 
+### Changed
+- Estimator "maxLeaseId" renamed to "maxUID", as used by option `dgraph.partitioner.uidRange.estimator`
+
 ### Fixed
 - Work with maxUID values that cannot be parsed
 - Handle maxUID values larger than Long.MaxValue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [UNRELEASED] - YYYY-MM-DD
 
 ### Changed
-- Estimator "maxLeaseId" renamed to "maxUID", as used with option `dgraph.partitioner.uidRange.estimator`
+- Estimator "maxLeaseId" renamed to "maxUid", as used with option `dgraph.partitioner.uidRange.estimator`
 
 ### Fixed
-- Work with maxUID values that cannot be parsed
-- Handle maxUID values larger than Long.MaxValue
+- Work with maxUid values that cannot be parsed
+- Handle maxUid values larger than Long.MaxValue
 
 ## [0.9.0] - 2022-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [UNRELEASED] - YYYY-MM-DD
 
 ### Changed
-- Estimator "maxLeaseId" renamed to "maxUID", as used by option `dgraph.partitioner.uidRange.estimator`
+- Estimator "maxLeaseId" renamed to "maxUID", as used with option `dgraph.partitioner.uidRange.estimator`
 
 ### Fixed
 - Work with maxUID values that cannot be parsed

--- a/README.md
+++ b/README.md
@@ -633,7 +633,7 @@ set the chunk size to 100th or less.
 <!-- there is only one estimator left, no need to mention this until we have another
 The estimator can be selected with the `dgraph.partitioner.uidRange.estimator` option. These estimators are available:
 
-##### Cluster maxUID (formerly MaxLeaseId)
+##### Cluster maxUID (formerly maxLeaseId)
 
 The Dgraph cluster [maintains a maxUID](https://dgraph.io/docs/deploy/dgraph-zero/#more-about-the-state-endpoint), which is the largest possible uid.
 It grows as new uids are added to the cluster, so it serves as an upper estimate of the actual largest uid.

--- a/README.md
+++ b/README.md
@@ -633,12 +633,12 @@ set the chunk size to 100th or less.
 <!-- there is only one estimator left, no need to mention this until we have another
 The estimator can be selected with the `dgraph.partitioner.uidRange.estimator` option. These estimators are available:
 
-##### Cluster MaxLeaseId
+##### Cluster maxUID (formerly MaxLeaseId)
 
-The Dgraph cluster [maintains a maxLeaseId](https://dgraph.io/docs/deploy/#more-about-state-endpoint), which is the largest possible uid.
+The Dgraph cluster [maintains a maxUID](https://dgraph.io/docs/deploy/dgraph-zero/#more-about-the-state-endpoint), which is the largest possible uid.
 It grows as new uids are added to the cluster, so it serves as an upper estimate of the actual largest uid.
 Compared to the count estimator it is very cheap to retrieve this value.
-This estimator can be selected with the `maxLeaseId` value.
+This estimator can be selected with the `maxUID` value.
 -->
 
 ### Streamed Partitions

--- a/README.md
+++ b/README.md
@@ -633,12 +633,12 @@ set the chunk size to 100th or less.
 <!-- there is only one estimator left, no need to mention this until we have another
 The estimator can be selected with the `dgraph.partitioner.uidRange.estimator` option. These estimators are available:
 
-##### Cluster maxUID (formerly maxLeaseId)
+##### Cluster maxUid (formerly maxLeaseId)
 
-The Dgraph cluster [maintains a maxUID](https://dgraph.io/docs/deploy/dgraph-zero/#more-about-the-state-endpoint), which is the largest possible uid.
+The Dgraph cluster [maintains a maxUid](https://dgraph.io/docs/deploy/dgraph-zero/#more-about-the-state-endpoint), which is the largest existing uid.
 It grows as new uids are added to the cluster, so it serves as an upper estimate of the actual largest uid.
 Compared to the count estimator it is very cheap to retrieve this value.
-This estimator can be selected with the `maxUID` value.
+This estimator can be selected with the `maxUid` value.
 -->
 
 ### Streamed Partitions

--- a/python/gresearch/spark/dgraph/connector/__init__.py
+++ b/python/gresearch/spark/dgraph/connector/__init__.py
@@ -52,9 +52,11 @@ PredicatePartitionerPredicatesOption: str = "dgraph.partitioner.predicate.predic
 PredicatePartitionerPredicatesDefault: int = 1000
 UidRangePartitionerUidsPerPartOption: str = "dgraph.partitioner.uidRange.uidsPerPartition"
 UidRangePartitionerUidsPerPartDefault: int = 1000000
+UidRangePartitionerMaxPartsOption: str = "dgraph.partitioner.uidRange.maxPartitions"
+UidRangePartitionerMaxPartsDefault: int = 10000
 UidRangePartitionerEstimatorOption: str = "dgraph.partitioner.uidRange.estimator"
-MaxLeaseIdEstimatorOption: str = "maxLeaseId"
-UidRangePartitionerEstimatorDefault: str = MaxLeaseIdEstimatorOption
+MaxUidEstimatorOption: str = "maxUid"
+UidRangePartitionerEstimatorDefault: str = MaxUidEstimatorOption
 
 
 class DgraphReader:

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/package.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/package.scala
@@ -193,10 +193,10 @@ package object connector {
   val UidRangePartitionerMaxPartsOption: String = "dgraph.partitioner.uidRange.maxPartitions"
   val UidRangePartitionerMaxPartsDefault: Int = 10000
   val UidRangePartitionerEstimatorOption: String = "dgraph.partitioner.uidRange.estimator"
-  val MaxLeaseIdEstimatorOption: String = "maxLeaseId"
-  val UidRangePartitionerEstimatorDefault: String = MaxLeaseIdEstimatorOption
+  val MaxUidEstimatorOption: String = "maxUid"
+  val UidRangePartitionerEstimatorDefault: String = MaxUidEstimatorOption
   // for testing purposes only
-  val MaxLeaseIdEstimatorIdOption: String = s"$UidRangePartitionerEstimatorOption.$MaxLeaseIdEstimatorOption.id"
+  val MaxUidEstimatorIdOption: String = s"$UidRangePartitionerEstimatorOption.$MaxUidEstimatorOption.id"
 
   def toChannel(target: Target): ManagedChannel = NettyChannelBuilder.forTarget(target.toString).usePlaintext().maxInboundMessageSize(24 * 1024 * 1024).build()
 

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/EstimatorProviderOption.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/EstimatorProviderOption.scala
@@ -26,10 +26,10 @@ trait EstimatorProviderOption extends ConfigParser with ClusterStateHelper with 
                          clusterState: ClusterState): UidCardinalityEstimator = {
     val name = getStringOption(option, options, default)
     name match {
-      case MaxLeaseIdEstimatorOption =>
-        val maxLeaseId = getIntOption(MaxLeaseIdEstimatorIdOption, options).map(UnsignedLong.valueOf(_))
-        maxLeaseId.foreach(id => log.warn(s"using configured maxLeaseId=$id for uid cardinality estimator"))
-        UidCardinalityEstimator.forMaxLeaseId(maxLeaseId.orElse(clusterState.maxLeaseId))
+      case MaxUidEstimatorOption =>
+        val maxUid = getIntOption(MaxUidEstimatorIdOption, options).map(UnsignedLong.valueOf(_))
+        maxUid.foreach(id => log.warn(s"using configured $MaxUidEstimatorIdOption=$id for uid cardinality estimator"))
+        UidCardinalityEstimator.forMaxUid(maxUid.orElse(clusterState.maxUid))
       case _ => throw new IllegalArgumentException(s"Unknown uid cardinality estimator: $name")
     }
   }

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/UidCardinalityEstimator.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/UidCardinalityEstimator.scala
@@ -49,10 +49,10 @@ abstract class UidCardinalityEstimatorBase extends UidCardinalityEstimator {
 
 }
 
-case class MaxLeaseIdUidCardinalityEstimator(maxLeaseId: Option[UnsignedLong]) extends UidCardinalityEstimatorBase {
+case class MaxUidUidCardinalityEstimator(maxUid: Option[UnsignedLong]) extends UidCardinalityEstimatorBase {
 
-  if (maxLeaseId.exists(_.compareTo(UnsignedLong.ZERO) <= 0))
-    throw new IllegalArgumentException(s"uidCardinality must be larger than zero: $maxLeaseId")
+  if (maxUid.exists(_.compareTo(UnsignedLong.ZERO) <= 0))
+    throw new IllegalArgumentException(s"uidCardinality maxUid must be larger than zero: $maxUid")
 
   /**
    * Estimates the cardinality of uids in the given partition,
@@ -62,11 +62,11 @@ case class MaxLeaseIdUidCardinalityEstimator(maxLeaseId: Option[UnsignedLong]) e
    * @return estimated number of uids or None
    */
   override def uidCardinality(partition: Partition): Option[UnsignedLong] =
-    super.uidCardinality(partition).orElse(maxLeaseId)
+    super.uidCardinality(partition).orElse(maxUid)
 
 }
 
 object UidCardinalityEstimator {
-  def forMaxLeaseId(maxLeaseId: Option[UnsignedLong]): UidCardinalityEstimator =
-    MaxLeaseIdUidCardinalityEstimator(maxLeaseId)
+  def forMaxUid(maxUid: Option[UnsignedLong]): UidCardinalityEstimator =
+    MaxUidUidCardinalityEstimator(maxUid)
 }

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestClusterState.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestClusterState.scala
@@ -27,18 +27,18 @@ class TestClusterState extends AnyFunSpec {
 
   describe("ClusterState") {
 
-    it("should handle numeric maxLeaseIds") {
+    it("should handle numeric unsigned longs") {
       assert(ClusterState.getUnsignedLongFromJson(new JsonPrimitive("1234")) === Success(UnsignedLong.valueOf(1234)))
       assert(ClusterState.getUnsignedLongFromJson(new JsonPrimitive(Long.MaxValue.toString)) === Success(UnsignedLong.valueOf(Long.MaxValue)))
       assert(ClusterState.getUnsignedLongFromJson(new JsonPrimitive((BigInt(Long.MaxValue) + 1).toString())) === Success(UnsignedLong.valueOf("9223372036854775808")))
       assert(ClusterState.getUnsignedLongFromJson(new JsonPrimitive("18446055125930680484")) === Success(UnsignedLong.valueOf("18446055125930680484")))
     }
 
-    it("should handle non-numeric maxLeaseIds") {
-      val bigint = ClusterState.getUnsignedLongFromJson(new JsonPrimitive("123e4"))
-      assert(bigint.isFailure)
-      assert(bigint.asInstanceOf[Failure[UnsignedLong]].exception.isInstanceOf[NumberFormatException])
-      assert(bigint.asInstanceOf[Failure[UnsignedLong]].exception.getMessage === "123e4")
+    it("should handle non-numeric unsigned longs") {
+      val long = ClusterState.getUnsignedLongFromJson(new JsonPrimitive("123e4"))
+      assert(long.isFailure)
+      assert(long.asInstanceOf[Failure[UnsignedLong]].exception.isInstanceOf[NumberFormatException])
+      assert(long.asInstanceOf[Failure[UnsignedLong]].exception.getMessage === "123e4")
     }
 
     it("should handle un-prefixed predicates") {
@@ -138,7 +138,7 @@ class TestClusterState extends AnyFunSpec {
           |      "leader": true
           |    }
           |  },
-          |  "maxLeaseId": "10000",
+          |  "maxUID": "10000",
           |  "maxTxnTs": "20000",
           |  "maxRaftId": "1",
           |  "cid": "5aacce50-a95f-440b-a32e-fbe6b4003980",
@@ -160,7 +160,7 @@ class TestClusterState extends AnyFunSpec {
         "1" -> Set("dgraph.graphql.schema", "dgraph.graphql.xid", "dgraph.type", "director"),
         "2" -> Set("name", "release_date", "revenue")
       ))
-      assert(state.maxLeaseId.map(_.intValue()) === Some(10000))
+      assert(state.maxUid.map(_.intValue()) === Some(10000))
       assert(state.cid === UUID.fromString("5aacce50-a95f-440b-a32e-fbe6b4003980"))
     }
 
@@ -177,7 +177,7 @@ class TestClusterState extends AnyFunSpec {
 
         val state = ClusterState.fromJson(Json(json))
 
-        assert(state.maxLeaseId.map(_.intValue()) === Some(10000))
+        assert(state.maxUid.map(_.intValue()) === Some(10000))
       }
 
       it(s"should handle Json with large $field") {
@@ -192,7 +192,7 @@ class TestClusterState extends AnyFunSpec {
 
         val state = ClusterState.fromJson(Json(json))
 
-        assert(state.maxLeaseId === Some(UnsignedLong.valueOf("18446055125930680484")))
+        assert(state.maxUid === Some(UnsignedLong.valueOf("18446055125930680484")))
       }
 
       it(s"should handle Json with zero $field") {
@@ -207,7 +207,7 @@ class TestClusterState extends AnyFunSpec {
 
         val state = ClusterState.fromJson(Json(json))
 
-        assert(state.maxLeaseId === Some(UnsignedLong.ZERO))
+        assert(state.maxUid === Some(UnsignedLong.ZERO))
       }
 
       it(s"should handle Json with negative $field") {
@@ -222,7 +222,7 @@ class TestClusterState extends AnyFunSpec {
 
         val state = ClusterState.fromJson(Json(json))
 
-        assert(state.maxLeaseId === None)
+        assert(state.maxUid === None)
       }
 
       it(s"should handle Json with non-numeric $field") {
@@ -237,11 +237,11 @@ class TestClusterState extends AnyFunSpec {
 
         val state = ClusterState.fromJson(Json(json))
 
-        assert(state.maxLeaseId === None)
+        assert(state.maxUid === None)
       }
     }
 
-    it("should handle Json with no maxLeasId / maxUID") {
+    it("should handle Json with no maxLeaseId / maxUID") {
       val json =
         """{
            |  "groups": {},
@@ -252,7 +252,7 @@ class TestClusterState extends AnyFunSpec {
 
       val state = ClusterState.fromJson(Json(json))
 
-      assert(state.maxLeaseId === None)
+      assert(state.maxUid === None)
     }
 
     it("should handle Json with null predicate prefix") {
@@ -400,7 +400,7 @@ class TestClusterState extends AnyFunSpec {
         "1" -> Set("dgraph.graphql.schema", "dgraph.type"),
         "2" -> Set("director", "name")
       ))
-      assert(state.maxLeaseId.map(_.intValue()) === Some(10000))
+      assert(state.maxUid.map(_.intValue()) === Some(10000))
       assert(state.cid === UUID.fromString("350fd4f5-771d-4021-8ef9-cd1b79aa6ea0"))
     }
 
@@ -549,7 +549,7 @@ class TestClusterState extends AnyFunSpec {
         "1" -> Set("dgraph.graphql.schema", "dgraph.type"),
         "2" -> Set("director")  // predicate name is ignored as it is not in the default namespace
       ))
-      assert(state.maxLeaseId.map(_.intValue()) === Some(10000))
+      assert(state.maxUid.map(_.intValue()) === Some(10000))
       assert(state.cid === UUID.fromString("350fd4f5-771d-4021-8ef9-cd1b79aa6ea0"))
     }
   }

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestClusterStateProvider.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/TestClusterStateProvider.scala
@@ -16,7 +16,6 @@
 
 package uk.co.gresearch.spark.dgraph.connector
 
-import com.google.common.primitives.UnsignedLong
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.scalatest.funspec.AnyFunSpec
 import uk.co.gresearch.spark.dgraph.DgraphTestCluster
@@ -38,7 +37,7 @@ class TestClusterStateProvider extends AnyFunSpec with DgraphTestCluster {
       val actualPredicates = state.get.groupPredicates("1")
       val expectedPredicates = Set("name", "title", "starring", "running_time", "release_date", "director", "revenue", "dgraph.type")
       assert(expectedPredicates.diff(actualPredicates) === Set.empty)
-      assert(state.get.maxLeaseId.map(_.intValue()) === Some(10000))
+      assert(state.get.maxUid.map(_.intValue()) === Some(10000))
     }
 
     it("should retrieve cluster states") {
@@ -49,7 +48,7 @@ class TestClusterStateProvider extends AnyFunSpec with DgraphTestCluster {
       val actualPredicates = state.groupPredicates("1")
       val expectedPredicates = Set("name", "title", "starring", "running_time", "release_date", "director", "revenue", "dgraph.type")
       assert(actualPredicates === expectedPredicates)
-      assert(state.maxLeaseId.map(_.intValue()) === Some(10000))
+      assert(state.maxUid.map(_.intValue()) === Some(10000))
     }
 
     it("should fail for unavailable cluster") {

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestPartitionerProvider.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestPartitionerProvider.scala
@@ -36,8 +36,8 @@ class TestPartitionerProvider extends AnyFunSpec {
     UUID.randomUUID()
   )
   val transaction: Option[Transaction] = Some(Transaction(TxnContext.newBuilder().build()))
-  val maxLeaseEstimator: UidCardinalityEstimator = MaxLeaseIdUidCardinalityEstimator(state.maxLeaseId)
-  assert(UidRangePartitionerEstimatorDefault === MaxLeaseIdEstimatorOption, "tests assume this default estimator")
+  val maxLeaseEstimator: UidCardinalityEstimator = MaxUidUidCardinalityEstimator(state.maxUid)
+  assert(UidRangePartitionerEstimatorDefault === MaxUidEstimatorOption, "tests assume this default estimator")
 
   describe("PartitionerProvider") {
 
@@ -86,13 +86,13 @@ class TestPartitionerProvider extends AnyFunSpec {
           PredicatePartitionerPredicatesOption -> "1",
           UidRangePartitionerUidsPerPartOption -> "2",
           UidRangePartitionerMaxPartsOption -> "3",
-          UidRangePartitionerEstimatorOption -> MaxLeaseIdEstimatorOption
+          UidRangePartitionerEstimatorOption -> MaxUidEstimatorOption
         ).asJava
       )
       val partitioner = provider.getPartitioner(schema, state, transaction, options)
 
       val predicatePart = PredicatePartitioner(schema, state, 1)
-      val expected = UidRangePartitioner(predicatePart, 2, 3, MaxLeaseIdUidCardinalityEstimator(state.maxLeaseId))
+      val expected = UidRangePartitioner(predicatePart, 2, 3, MaxUidUidCardinalityEstimator(state.maxUid))
       assert(partitioner === expected)
     }
 
@@ -131,7 +131,7 @@ class TestPartitionerProvider extends AnyFunSpec {
       val options = new CaseInsensitiveStringMap(Map(
         PartitionerOption -> "uid-range",
         UidRangePartitionerUidsPerPartOption -> "2",
-        UidRangePartitionerEstimatorOption -> MaxLeaseIdEstimatorOption,
+        UidRangePartitionerEstimatorOption -> MaxUidEstimatorOption,
       ).asJava)
       val partitioner = provider.getPartitioner(schema, state, transaction, options)
       assert(partitioner === uidRange.copy(uidsPerPartition = 2, uidCardinalityEstimator = maxLeaseEstimator))
@@ -143,7 +143,7 @@ class TestPartitionerProvider extends AnyFunSpec {
         PartitionerOption -> "alpha+uid-range",
         AlphaPartitionerPartitionsOption -> "2",
         UidRangePartitionerUidsPerPartOption -> "2",
-        UidRangePartitionerEstimatorOption -> MaxLeaseIdEstimatorOption,
+        UidRangePartitionerEstimatorOption -> MaxUidEstimatorOption,
       ).asJava)
       val partitioner = provider.getPartitioner(schema, state, transaction, options)
       assert(partitioner === uidRange.copy(partitioner = alpha.copy(partitionsPerAlpha = 2),
@@ -156,7 +156,7 @@ class TestPartitionerProvider extends AnyFunSpec {
         PartitionerOption -> "predicate+uid-range",
         PredicatePartitionerPredicatesOption -> "2",
         UidRangePartitionerUidsPerPartOption -> "2",
-        UidRangePartitionerEstimatorOption -> MaxLeaseIdEstimatorOption,
+        UidRangePartitionerEstimatorOption -> MaxUidEstimatorOption,
       ).asJava)
       val partitioner = provider.getPartitioner(schema, state, transaction, options)
       assert(partitioner === uidRange.copy(partitioner = pred.copy(predicatesPerPartition = 2),

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestUidCardinalityEstimator.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestUidCardinalityEstimator.scala
@@ -53,20 +53,20 @@ class TestUidCardinalityEstimator extends AnyFunSpec {
     doTestUidCardinalityEstimatorBase(new UidCardinalityEstimatorBase {}, None)
   }
 
-  describe("MaxLeaseIdUidCardinalityEstimator") {
-    describe("with some maxLeaseId") {
-      doTestUidCardinalityEstimatorBase(MaxLeaseIdUidCardinalityEstimator(Some(UnsignedLong.valueOf(1234))), Some(1234))
+  describe("MaxUidUidCardinalityEstimator") {
+    describe("with some maxUid") {
+      doTestUidCardinalityEstimatorBase(MaxUidUidCardinalityEstimator(Some(UnsignedLong.valueOf(1234))), Some(1234))
     }
-    describe("with no maxLeaseId") {
-      doTestUidCardinalityEstimatorBase(MaxLeaseIdUidCardinalityEstimator(None), None)
+    describe("with no maxUid") {
+      doTestUidCardinalityEstimatorBase(MaxUidUidCardinalityEstimator(None), None)
     }
 
     it("should fail on negative or zero max uids") {
       assertThrows[IllegalArgumentException] {
-        UidCardinalityEstimator.forMaxLeaseId(Some(UnsignedLong.valueOf(-1)))
+        UidCardinalityEstimator.forMaxUid(Some(UnsignedLong.valueOf(-1)))
       }
       assertThrows[IllegalArgumentException] {
-        UidCardinalityEstimator.forMaxLeaseId(Some(UnsignedLong.valueOf(0)))
+        UidCardinalityEstimator.forMaxUid(Some(UnsignedLong.valueOf(0)))
       }
     }
 

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestUidRangePartitioner.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestUidRangePartitioner.scala
@@ -60,7 +60,7 @@ class TestUidRangePartitioner extends AnyFunSpec {
       testSizes.foreach { size =>
 
         it(s"should decorate $label partitioner with ${size} uids per partition") {
-          val uidPartitioner = UidRangePartitioner(partitioner, size, UidRangePartitionerMaxPartsDefault, UidCardinalityEstimator.forMaxLeaseId(clusterState.maxLeaseId))
+          val uidPartitioner = UidRangePartitioner(partitioner, size, UidRangePartitionerMaxPartsDefault, UidCardinalityEstimator.forMaxUid(clusterState.maxUid))
           val partitions = partitioner.getPartitions
           val uidPartitions = uidPartitioner.getPartitions
 
@@ -82,7 +82,7 @@ class TestUidRangePartitioner extends AnyFunSpec {
     testPartitioners.foreach{ case (partitioner, label) =>
 
       it(s"should noop $label partitioner with too large uidsPerPartition") {
-        val uidPartitioner = UidRangePartitioner(partitioner, clusterState.maxLeaseId.get.intValue(), 10, UidCardinalityEstimator.forMaxLeaseId(clusterState.maxLeaseId))
+        val uidPartitioner = UidRangePartitioner(partitioner, clusterState.maxUid.get.intValue(), 10, UidCardinalityEstimator.forMaxUid(clusterState.maxUid))
         assert(uidPartitioner.getPartitions === partitioner.getPartitions)
       }
 
@@ -90,47 +90,47 @@ class TestUidRangePartitioner extends AnyFunSpec {
 
     it("should fail on null partitioner") {
       assertThrows[IllegalArgumentException] {
-        UidRangePartitioner(null, 1, 2, UidCardinalityEstimator.forMaxLeaseId(Some(UnsignedLong.valueOf(1000))))
+        UidRangePartitioner(null, 1, 2, UidCardinalityEstimator.forMaxUid(Some(UnsignedLong.valueOf(1000))))
       }
     }
 
     it("should fail on decorating uid partitioner") {
       // with too low maxPartitions, this partitioner does mot range-partition the singleton partitioner
       // and the assertion will not pass, see test "should not partition into more than max partitions"
-      val uidPartitioner = UidRangePartitioner(singleton, 100, 10, UidCardinalityEstimator.forMaxLeaseId(Some(UnsignedLong.valueOf(1000))))
+      val uidPartitioner = UidRangePartitioner(singleton, 100, 10, UidCardinalityEstimator.forMaxUid(Some(UnsignedLong.valueOf(1000))))
       assertThrows[IllegalArgumentException] {
-        UidRangePartitioner(uidPartitioner, 1, 2, UidCardinalityEstimator.forMaxLeaseId(Some(UnsignedLong.valueOf(1000))))
+        UidRangePartitioner(uidPartitioner, 1, 2, UidCardinalityEstimator.forMaxUid(Some(UnsignedLong.valueOf(1000))))
       }
     }
 
     it("should fail on negative uidsPerPartition") {
       assertThrows[IllegalArgumentException] {
-        UidRangePartitioner(singleton, -1, 2, UidCardinalityEstimator.forMaxLeaseId(Some(UnsignedLong.valueOf(1000))))
+        UidRangePartitioner(singleton, -1, 2, UidCardinalityEstimator.forMaxUid(Some(UnsignedLong.valueOf(1000))))
       }
     }
 
     it("should fail on zero maxPartitions") {
       assertThrows[IllegalArgumentException] {
-        UidRangePartitioner(singleton, 1, 0, UidCardinalityEstimator.forMaxLeaseId(Some(UnsignedLong.valueOf(1000))))
+        UidRangePartitioner(singleton, 1, 0, UidCardinalityEstimator.forMaxUid(Some(UnsignedLong.valueOf(1000))))
       }
     }
 
     it("should fail on negative maxPartitions") {
       assertThrows[IllegalArgumentException] {
-        UidRangePartitioner(singleton, 1, -1, UidCardinalityEstimator.forMaxLeaseId(Some(UnsignedLong.valueOf(1000))))
+        UidRangePartitioner(singleton, 1, -1, UidCardinalityEstimator.forMaxUid(Some(UnsignedLong.valueOf(1000))))
       }
     }
 
     it("should not partition into more than max partitions") {
-      val uidPartitioner1 = UidRangePartitioner(singleton, 100, 5, UidCardinalityEstimator.forMaxLeaseId(Some(UnsignedLong.valueOf(1000))))
+      val uidPartitioner1 = UidRangePartitioner(singleton, 100, 5, UidCardinalityEstimator.forMaxUid(Some(UnsignedLong.valueOf(1000))))
       assert(uidPartitioner1.getPartitions === singleton.getPartitions)
-      val uidPartitioner2 = UidRangePartitioner(singleton, 100, 10, UidCardinalityEstimator.forMaxLeaseId(Some(UnsignedLong.valueOf(1000))))
+      val uidPartitioner2 = UidRangePartitioner(singleton, 100, 10, UidCardinalityEstimator.forMaxUid(Some(UnsignedLong.valueOf(1000))))
       assert(uidPartitioner2.getPartitions !== singleton.getPartitions)
     }
 
     it("should support what decorated partitioner supports") {
       val partitioner = PredicatePartitioner(schema, clusterState, 1)
-      val uidPartitioner = UidRangePartitioner(partitioner, 2, 3, UidCardinalityEstimator.forMaxLeaseId(Some(UnsignedLong.valueOf(1000))))
+      val uidPartitioner = UidRangePartitioner(partitioner, 2, 3, UidCardinalityEstimator.forMaxUid(Some(UnsignedLong.valueOf(1000))))
 
       Seq[Set[Filter]](
         Set(SubjectIsIn(Uid("0x1"))),
@@ -152,7 +152,7 @@ class TestUidRangePartitioner extends AnyFunSpec {
 
     it("should forward filters to decorated partitioner") {
       val partitioner = PredicatePartitioner(schema, clusterState, 1)
-      val uidPartitioner = UidRangePartitioner(partitioner, 2, 3, UidCardinalityEstimator.forMaxLeaseId(Some(UnsignedLong.valueOf(1000))))
+      val uidPartitioner = UidRangePartitioner(partitioner, 2, 3, UidCardinalityEstimator.forMaxUid(Some(UnsignedLong.valueOf(1000))))
       // deliberately not EmptyFilters here to test with our own instance
       val filters = Filters(Set.empty, Set.empty)
       val actual =
@@ -164,7 +164,7 @@ class TestUidRangePartitioner extends AnyFunSpec {
 
     it("should forward projection to decorated partitioner") {
       val partitioner = PredicatePartitioner(schema, clusterState, 1)
-      val uidPartitioner = UidRangePartitioner(partitioner, 2, 3, UidCardinalityEstimator.forMaxLeaseId(Some(UnsignedLong.valueOf(1000))))
+      val uidPartitioner = UidRangePartitioner(partitioner, 2, 3, UidCardinalityEstimator.forMaxUid(Some(UnsignedLong.valueOf(1000))))
       val projection = schema.predicates.toSeq
       val actual =
         uidPartitioner.withProjection(projection)
@@ -178,7 +178,7 @@ class TestUidRangePartitioner extends AnyFunSpec {
       val langPreds = Set("pred2")
       val langSchema = Schema(schema.predicates.map(p => if (langPreds.contains(p.predicateName)) p.copy(isLang = true) else p))
       val partitioner = PredicatePartitioner(langSchema, clusterState, 5)
-      val uidPartitioner = UidRangePartitioner(partitioner, 500, 10, UidCardinalityEstimator.forMaxLeaseId(Some(UnsignedLong.valueOf(1000))))
+      val uidPartitioner = UidRangePartitioner(partitioner, 500, 10, UidCardinalityEstimator.forMaxUid(Some(UnsignedLong.valueOf(1000))))
       val partitions = uidPartitioner.getPartitions
       assert(partitions === Seq(
         Partition(Seq(Target("host1:9080"), Target("host2:9080"))).has(Set("pred1"), Set.empty).range(1, 501).getAll,

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestEdgeSource.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestEdgeSource.scala
@@ -164,8 +164,8 @@ class TestEdgeSource extends AnyFunSpec
           .options(Map(
             PartitionerOption -> UidRangePartitionerOption,
             UidRangePartitionerUidsPerPartOption -> "2",
-            UidRangePartitionerEstimatorOption -> MaxLeaseIdEstimatorOption,
-            MaxLeaseIdEstimatorIdOption -> dgraph.highestUid.toString
+            UidRangePartitionerEstimatorOption -> MaxUidEstimatorOption,
+            MaxUidEstimatorIdOption -> dgraph.highestUid.toString
           ))
           .dgraph.edges(target)
           .mapPartitions(part => Iterator(part.map(_.getLong(0)).toSet))

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestNodeSource.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestNodeSource.scala
@@ -417,7 +417,7 @@ class TestNodeSource extends AnyFunSpec
             PartitionerOption -> s"$PredicatePartitionerOption+$UidRangePartitionerOption",
             PredicatePartitionerPredicatesOption -> "1",
             UidRangePartitionerUidsPerPartOption -> "1",
-            MaxLeaseIdEstimatorIdOption -> dgraph.highestUid.toString
+            MaxUidEstimatorIdOption -> dgraph.highestUid.toString
           ))
           .dgraph.nodes(dgraph.target)
       )
@@ -519,7 +519,7 @@ class TestNodeSource extends AnyFunSpec
             .options(Map(
               PartitionerOption -> UidRangePartitionerOption,
               UidRangePartitionerUidsPerPartOption -> "7",
-              MaxLeaseIdEstimatorIdOption -> dgraph.highestUid.toString
+              MaxUidEstimatorIdOption -> dgraph.highestUid.toString
             ))
             .dgraph.nodes(target)
             .as[TypedNode]

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestTriplesSource.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/sources/TestTriplesSource.scala
@@ -473,7 +473,7 @@ class TestTriplesSource extends AnyFunSpec
           .options(Map(
             PartitionerOption -> s"$UidRangePartitionerOption",
             UidRangePartitionerUidsPerPartOption -> "7",
-            MaxLeaseIdEstimatorIdOption -> dgraph.highestUid.toString
+            MaxUidEstimatorIdOption -> dgraph.highestUid.toString
           ))
           .dgraph.triples(dgraph.target)
           .rdd
@@ -497,7 +497,7 @@ class TestTriplesSource extends AnyFunSpec
             PartitionerOption -> s"$PredicatePartitionerOption+$UidRangePartitionerOption",
             PredicatePartitionerPredicatesOption -> "2",
             UidRangePartitionerUidsPerPartOption -> "5",
-            MaxLeaseIdEstimatorIdOption -> dgraph.highestUid.toString
+            MaxUidEstimatorIdOption -> dgraph.highestUid.toString
           ))
           .dgraph.triples(dgraph.target)
           .rdd
@@ -525,7 +525,7 @@ class TestTriplesSource extends AnyFunSpec
             .options(Map(
               PartitionerOption -> UidRangePartitionerOption,
               UidRangePartitionerUidsPerPartOption -> "7",
-              MaxLeaseIdEstimatorIdOption -> dgraph.highestUid.toString
+              MaxUidEstimatorIdOption -> dgraph.highestUid.toString
             ))
             .dgraph.triples(dgraph.target)
         )


### PR DESCRIPTION
This renames `maxLeaseId` to `maxUid` as this has changed in Dgraph years ago.