### PR TITLE
Make uid unsigned long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Work with maxUid values that cannot be parsed
 - Handle maxUid values larger than Long.MaxValue
+- Supports full unsigned long (64 bits) value range of Dgraph uids, mapped into signed longs
 
 ## [0.9.0] - 2022-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Estimator "maxLeaseId" renamed to "maxUid", as used with option `dgraph.partitioner.uidRange.estimator`
 
 ### Fixed
-- Work with maxUid values that cannot be parsed
-- Handle maxUid values larger than Long.MaxValue
-- Supports full unsigned long (64 bits) value range of Dgraph uids, mapped into signed longs
+- Work with maxUid values that cannot be parsed ([pull #216](https://github.com/G-Research/spark-dgraph-connector/pull/216)).
+- Handle maxUid values larger than Long.MaxValue ([pull #216](https://github.com/G-Research/spark-dgraph-connector/pull/216)).
+- Handle Dgraph data type "default" as plain strings ([pull #223](https://github.com/G-Research/spark-dgraph-connector/pull/223)).
+- Supports full unsigned long (64 bits) value range of Dgraph uids, mapped into signed longs ([pull #222](https://github.com/G-Research/spark-dgraph-connector/pull/222)).
 
 ## [0.9.0] - 2022-07-14
 

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/Operator.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/Operator.scala
@@ -16,6 +16,8 @@
 
 package uk.co.gresearch.spark.dgraph.connector
 
+import com.google.common.primitives.UnsignedLong
+
 /**
  * Operator for PartitionQuery.
  */
@@ -64,7 +66,7 @@ case class Uids(uids: Set[Uid]) extends Operator
 case class UidRange(first: Uid, until: Uid) extends Operator {
   if (first >= until)
     throw new IllegalArgumentException(s"UidRange first uid (is $first) must be before until (is $until)")
-  def length: Long = until.uid - first.uid
+  def length: UnsignedLong = until.uid.minus(first.uid)
 }
 
 /**

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/encoder/EdgeEncoder.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/encoder/EdgeEncoder.scala
@@ -61,7 +61,7 @@ case class EdgeEncoder(predicates: Map[String, connector.Predicate])
    * @return an internal row
    */
   override def asInternalRow(s: Uid, p: String, o: Any): Option[InternalRow] = o match {
-    case uid: Uid => Some(InternalRow(s.uid, UTF8String.fromString(p), uid.uid))
+    case uid: Uid => Some(InternalRow(s.uid.longValue(), UTF8String.fromString(p), uid.uid.longValue()))
     case _ => None
   }
 

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/encoder/StringTripleEncoder.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/encoder/StringTripleEncoder.scala
@@ -61,7 +61,7 @@ case class StringTripleEncoder(predicates: Map[String, Predicate])
    */
   override def asInternalRow(s: Uid, p: String, o: Any): Option[InternalRow] =
     Some(InternalRow(
-      s.uid,
+      s.uid.longValue(),
       UTF8String.fromString(p),
       UTF8String.fromString(o.toString),
       UTF8String.fromString(getType(o))

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/encoder/TripleEncoder.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/encoder/TripleEncoder.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import uk.co.gresearch.spark.dgraph.connector.{Json, Logging, Predicate, Uid}
 
 import scala.collection.JavaConverters._
+import scala.util.{Failure, Success, Try}
 
 /**
  * Encodes triples as InternalRows from Dgraph json results.
@@ -69,7 +70,11 @@ trait TripleEncoder extends JsonNodeInternalRowEncoder with Logging {
         .flatMap { case (p, v, t) =>
           getValues(v)
             .flatMap(v =>
-              asInternalRow(uid, p, getValue(v, t))
+              Try(asInternalRow(uid, p, getValue(v, t))) match {
+                case Failure(exception) =>
+                  throw new IllegalArgumentException(s"Cannot parse value '$v' of type $t for predicate $p and uid $uid", exception)
+                case Success(value) => value
+              }
             )
         }
     } catch {

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/encoder/TripleEncoder.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/encoder/TripleEncoder.scala
@@ -70,6 +70,7 @@ trait TripleEncoder extends JsonNodeInternalRowEncoder with Logging {
         .flatMap { case (p, v, t) =>
           getValues(v)
             .flatMap(v =>
+              // give more context to non-parsable values
               Try(asInternalRow(uid, p, getValue(v, t))) match {
                 case Failure(exception) =>
                   throw new IllegalArgumentException(s"Cannot parse value '$v' of type $t for predicate $p and uid $uid", exception)

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/encoder/TypedNodeEncoder.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/encoder/TypedNodeEncoder.scala
@@ -77,7 +77,7 @@ case class TypedNodeEncoder(predicates: Map[String, Predicate])
     } else {
       // order has to align with TypedNode case class
       val valuesWithoutObject = Seq(
-        s.uid,
+        s.uid.longValue(),
         UTF8String.fromString(p),
         null, // string
         null, // long

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/encoder/TypedTripleEncoder.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/encoder/TypedTripleEncoder.scala
@@ -74,7 +74,7 @@ case class TypedTripleEncoder(predicates: Map[String, Predicate])
 
     // order has to align with TypedTriple
     val valuesWithoutObject = Seq(
-      s.uid,
+      s.uid.longValue(),
       UTF8String.fromString(p),
       null, // uid
       null, // string
@@ -90,7 +90,7 @@ case class TypedTripleEncoder(predicates: Map[String, Predicate])
     // order has to align with TypedTriple
     val (objectValueIndex, objectValue) =
       objectType match {
-        case "uid" => (2, o.asInstanceOf[Uid].uid)
+        case "uid" => (2, o.asInstanceOf[Uid].uid.longValue())
         case "string" => (3, UTF8String.fromString(o.asInstanceOf[String]))
         case "long" => (4, o)
         case "double" => (5, o)

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/encoder/WideNodeEncoder.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/encoder/WideNodeEncoder.scala
@@ -117,7 +117,7 @@ case class WideNodeEncoder(predicates: Set[Predicate], projectedSchema: Option[S
           case (Some(p), Some(t), o) =>
             val obj = getValue(o, t)
             val objectValue = t match {
-              case "subject" => obj.asInstanceOf[Uid].uid
+              case "subject" => obj.asInstanceOf[Uid].uid.longValue()
               case "string" => UTF8String.fromString(obj.asInstanceOf[String])
               case "int" => obj
               case "float" => obj

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/package.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/package.scala
@@ -16,8 +16,9 @@
 
 package uk.co.gresearch.spark.dgraph
 
-import java.sql.Timestamp
+import com.google.common.primitives.UnsignedLong
 
+import java.sql.Timestamp
 import io.dgraph.DgraphGrpc.DgraphStub
 import io.dgraph.DgraphProto.TxnContext
 import io.dgraph.{DgraphClient, DgraphGrpc}
@@ -58,29 +59,29 @@ package object connector {
                        objectPassword: Option[String],
                        objectType: String)
 
-  case class Uid(uid: Long) {
-    if (uid < 0) throw new IllegalArgumentException(s"Uid must be positive (is $uid)")
+  case class Uid(uid: UnsignedLong) {
+    if (uid.compareTo(UnsignedLong.ZERO) < 0) throw new IllegalArgumentException(s"Uid must be positive (is $uid)")
     override def toString: String = uid.toString
-    def toHexString: String = s"0x${uid.toHexString}"
-    def <(other: Uid): Boolean = uid < other.uid
-    def >=(other: Uid): Boolean = uid >= other.uid
-    def next: Uid = Uid(uid+1)
-    def before: Uid = Uid(uid-1)
+    def toHexString: String = s"0x${uid.toString(16)}"
+    def <(other: Uid): Boolean = uid.compareTo(other.uid) < 0
+    def >=(other: Uid): Boolean = uid.compareTo(other.uid) >= 0
+    def next: Uid = Uid(uid.plus(UnsignedLong.ONE))
+    def before: Uid = Uid(uid.minus(UnsignedLong.ONE))
   }
 
   object Uid {
-    def apply(uid: String): Uid = Uid(toLong(uid))
+    def apply(uid: String): Uid = Uid(toUnsignedLong(uid))
 
     def apply(uid: Any): Uid = uid match {
-      case l: Long => Uid(l)
+      case l: Long => Uid(UnsignedLong.valueOf(l))
       case i: Int => Uid(i.toLong)
       case a => Uid(a.toString)
     }
 
-    private def toLong(uid: String): Long =
+    private def toUnsignedLong(uid: String): UnsignedLong =
       Some(uid)
         .filter(_.startsWith("0x"))
-        .map(uid => java.lang.Long.valueOf(uid.substring(2), 16))
+        .map(uid => UnsignedLong.valueOf(uid.substring(2), 16))
         .getOrElse(throw new IllegalArgumentException("Dgraph uid is not a long prefixed with '0x': " + uid))
   }
 

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/package.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/package.scala
@@ -61,7 +61,7 @@ package object connector {
 
   case class Uid(uid: UnsignedLong) {
     if (uid.compareTo(UnsignedLong.ZERO) < 0) throw new IllegalArgumentException(s"Uid must be positive (is $uid)")
-    override def toString: String = uid.toString
+    override def toString: String = uid.longValue().toString
     def toHexString: String = s"0x${uid.toString(16)}"
     def <(other: Uid): Boolean = uid.compareTo(other.uid) < 0
     def >=(other: Uid): Boolean = uid.compareTo(other.uid) >= 0
@@ -70,12 +70,11 @@ package object connector {
   }
 
   object Uid {
-    def apply(uid: String): Uid = Uid(toUnsignedLong(uid))
-
     def apply(uid: Any): Uid = uid match {
+      case ul: UnsignedLong => Uid(ul)
       case l: Long => Uid(UnsignedLong.valueOf(l))
-      case i: Int => Uid(i.toLong)
-      case a => Uid(a.toString)
+      case i: Int => Uid(UnsignedLong.valueOf(i.toLong))
+      case a => Uid(toUnsignedLong(a.toString))
     }
 
     private def toUnsignedLong(uid: String): UnsignedLong =

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/UidCardinalityEstimator.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/UidCardinalityEstimator.scala
@@ -45,7 +45,7 @@ abstract class UidCardinalityEstimatorBase extends UidCardinalityEstimator {
    * @return estimated number of uids or None
    */
   override def uidCardinality(partition: Partition): Option[UnsignedLong] =
-    partition.uidRange.map(_.length).orElse(partition.uids.map(_.size.toLong)).map(UnsignedLong.valueOf)
+    partition.uidRange.map(_.length).orElse(partition.uids.map(_.size.toLong).map(UnsignedLong.valueOf))
 
 }
 

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/DgraphTestCluster.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/DgraphTestCluster.scala
@@ -145,7 +145,7 @@ class DgraphCluster(pathToInsertedJson: String = ".", alwaysStartUp: Boolean = f
     }
 
     val uid = attempt(1, 30)
-    Map("dgraph.graphql.schema" -> uid.uid)
+    Map("dgraph.graphql.schema" -> uid.uid.longValue())
   }
 
   case class TestEncoder() extends JsonNodeInternalRowEncoder with NoColumnInfo {
@@ -438,7 +438,7 @@ case class DgraphDockerContainer(name: String, version: String) extends Logging 
       .getAsJsonObject("data")
       .getAsJsonObject("uids")
       .entrySet().asScala
-      .map(e => e.getKey -> Uid(e.getValue.getAsString).uid)
+      .map(e => e.getKey -> Uid(e.getValue.getAsString).uid.longValue())
       .toMap
 
     assert(map.keys.toSet == Set(

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/encoder/TestEdgeEncoder.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/encoder/TestEdgeEncoder.scala
@@ -45,121 +45,6 @@ class TestEdgeEncoder extends AnyFunSpec {
     }
 
     it("should parse JSON response") {
-      val schema = Schema(Set(
-        Predicate("release_date", "datetime"),
-        Predicate("revenue", "float"),
-        Predicate("running_time", "int"),
-        Predicate("director", "uid"),
-        Predicate("starring", "uid")
-      ))
-
-      val json =
-        """
-          |{
-          |    "result": [
-          |      {
-          |        "uid": "0x1",
-          |        "name": "Star Wars: Episode IV - A New Hope",
-          |        "release_date": "1977-05-25T00:00:00Z",
-          |        "revenue": "775000000",
-          |        "running_time": 121,
-          |        "starring": [
-          |          {
-          |            "uid": "0x2"
-          |          },
-          |          {
-          |            "uid": "0x3"
-          |          },
-          |          {
-          |            "uid": "0x7"
-          |          }
-          |        ],
-          |        "director": [
-          |          {
-          |            "uid": "0x4"
-          |          }
-          |        ]
-          |      },
-          |      {
-          |        "uid": "0x2",
-          |        "name": "Luke Skywalker"
-          |      },
-          |      {
-          |        "uid": "0x3",
-          |        "name": "Han Solo"
-          |      },
-          |      {
-          |        "uid": "0x4",
-          |        "name": "George Lucas"
-          |      },
-          |      {
-          |        "uid": "0x5",
-          |        "name": "Irvin Kernshner"
-          |      },
-          |      {
-          |        "uid": "0x6",
-          |        "name": "Richard Marquand"
-          |      },
-          |      {
-          |        "uid": "0x7",
-          |        "name": "Princess Leia"
-          |      },
-          |      {
-          |        "uid": "0x8",
-          |        "name": "Star Wars: Episode V - The Empire Strikes Back",
-          |        "release_date": "1980-05-21T00:00:00Z",
-          |        "revenue": "534000000",
-          |        "running_time": 124,
-          |        "starring": [
-          |          {
-          |            "uid": "0x2"
-          |          },
-          |          {
-          |            "uid": "0x3"
-          |          },
-          |          {
-          |            "uid": "0x7"
-          |          }
-          |        ],
-          |        "director": [
-          |          {
-          |            "uid": "0x5"
-          |          }
-          |        ]
-          |      },
-          |      {
-          |        "uid": "0x9",
-          |        "name": "Star Wars: Episode VI - Return of the Jedi",
-          |        "release_date": "1983-05-25T00:00:00Z",
-          |        "revenue": "572000000",
-          |        "running_time": 131,
-          |        "starring": [
-          |          {
-          |            "uid": "0x2"
-          |          },
-          |          {
-          |            "uid": "0x3"
-          |          },
-          |          {
-          |            "uid": "0x7"
-          |          }
-          |        ],
-          |        "director": [
-          |          {
-          |            "uid": "0x6"
-          |          }
-          |        ]
-          |      },
-          |      {
-          |        "uid": "0xa",
-          |        "name": "Star Trek: The Motion Picture",
-          |        "release_date": "1979-12-07T00:00:00Z",
-          |        "revenue": "139000000",
-          |        "running_time": 132
-          |      }
-          |    ]
-          |  }""".stripMargin
-
       val encoder = EdgeEncoder(schema.predicateMap)
       val rows = encoder.fromJson(Json(json), "result")
       assert(rows.toSeq === Seq(
@@ -175,6 +60,17 @@ class TestEdgeEncoder extends AnyFunSpec {
         InternalRow(9L, UTF8String.fromString("starring"), 3L),
         InternalRow(9L, UTF8String.fromString("starring"), 7L),
         InternalRow(9L, UTF8String.fromString("director"), 6L),
+      ))
+    }
+
+    it("should parse JSON response with large uids") {
+      val encoder = EdgeEncoder(schema.predicateMap)
+      val rows = encoder.fromJson(Json(jsonWithLargeUids), "result")
+      assert(rows.toSeq === Seq(
+        InternalRow(-6346846686373277921L, UTF8String.fromString("starring"), 3100520392254949455L),
+        InternalRow(-6346846686373277921L, UTF8String.fromString("starring"), 999257064750498476L),
+        InternalRow(-6346846686373277921L, UTF8String.fromString("starring"), -1877623327044447073L),
+        InternalRow(-6346846686373277921L, UTF8String.fromString("director"), 8214320560726473464L),
       ))
     }
 

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/encoder/TestStringTripleEncoder.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/encoder/TestStringTripleEncoder.scala
@@ -79,122 +79,6 @@ class TestStringTripleEncoder extends AnyFunSpec {
   }
 
   it("should parse JSON response") {
-    val schema = Schema(Set(
-      Predicate("name", "string"),
-      Predicate("release_date", "datetime"),
-      Predicate("revenue", "float"),
-      Predicate("running_time", "int"),
-      Predicate("director", "uid"),
-      Predicate("starring", "uid")
-    ))
-
-    val json =
-      """
-        |{
-        |    "result": [
-        |      {
-        |        "uid": "0x1",
-        |        "name": "Star Wars: Episode IV - A New Hope",
-        |        "release_date": "1977-05-25T00:00:00Z",
-        |        "revenue": "775000000",
-        |        "running_time": 121,
-        |        "starring": [
-        |          {
-        |            "uid": "0x2"
-        |          },
-        |          {
-        |            "uid": "0x3"
-        |          },
-        |          {
-        |            "uid": "0x7"
-        |          }
-        |        ],
-        |        "director": [
-        |          {
-        |            "uid": "0x4"
-        |          }
-        |        ]
-        |      },
-        |      {
-        |        "uid": "0x2",
-        |        "name": "Luke Skywalker"
-        |      },
-        |      {
-        |        "uid": "0x3",
-        |        "name": "Han Solo"
-        |      },
-        |      {
-        |        "uid": "0x4",
-        |        "name": "George Lucas"
-        |      },
-        |      {
-        |        "uid": "0x5",
-        |        "name": "Irvin Kernshner"
-        |      },
-        |      {
-        |        "uid": "0x6",
-        |        "name": "Richard Marquand"
-        |      },
-        |      {
-        |        "uid": "0x7",
-        |        "name": "Princess Leia"
-        |      },
-        |      {
-        |        "uid": "0x8",
-        |        "name": "Star Wars: Episode V - The Empire Strikes Back",
-        |        "release_date": "1980-05-21T00:00:00Z",
-        |        "revenue": "534000000",
-        |        "running_time": 124,
-        |        "starring": [
-        |          {
-        |            "uid": "0x2"
-        |          },
-        |          {
-        |            "uid": "0x3"
-        |          },
-        |          {
-        |            "uid": "0x7"
-        |          }
-        |        ],
-        |        "director": [
-        |          {
-        |            "uid": "0x5"
-        |          }
-        |        ]
-        |      },
-        |      {
-        |        "uid": "0x9",
-        |        "name": "Star Wars: Episode VI - Return of the Jedi",
-        |        "release_date": "1983-05-25T00:00:00Z",
-        |        "revenue": "572000000",
-        |        "running_time": 131,
-        |        "starring": [
-        |          {
-        |            "uid": "0x2"
-        |          },
-        |          {
-        |            "uid": "0x3"
-        |          },
-        |          {
-        |            "uid": "0x7"
-        |          }
-        |        ],
-        |        "director": [
-        |          {
-        |            "uid": "0x6"
-        |          }
-        |        ]
-        |      },
-        |      {
-        |        "uid": "0xa",
-        |        "name": "Star Trek: The Motion Picture",
-        |        "release_date": "1979-12-07T00:00:00Z",
-        |        "revenue": "139000000",
-        |        "running_time": 132
-        |      }
-        |    ]
-        |  }""".stripMargin
-
     val encoder = StringTripleEncoder(schema.predicateMap)
     val rows = encoder.fromJson(Json(json), "result")
     assert(rows.toSeq === Seq(
@@ -233,7 +117,21 @@ class TestStringTripleEncoder extends AnyFunSpec {
       InternalRow(10L, UTF8String.fromString("revenue"), UTF8String.fromString("1.39E8"), UTF8String.fromString("double")),
       InternalRow(10L, UTF8String.fromString("running_time"), UTF8String.fromString("132"), UTF8String.fromString("long")),
     ))
+  }
 
+  it("should parse JSON response with large uids") {
+    val encoder = StringTripleEncoder(schema.predicateMap)
+    val rows = encoder.fromJson(Json(jsonWithLargeUids), "result")
+    assert(rows.toSeq === Seq(
+      InternalRow(-6346846686373277921L, UTF8String.fromString("name"), UTF8String.fromString("Star Wars: Episode IV - A New Hope"), UTF8String.fromString("string")),
+      InternalRow(-6346846686373277921L, UTF8String.fromString("release_date"), UTF8String.fromString("1977-05-25 00:00:00.0"), UTF8String.fromString("timestamp")),
+      InternalRow(-6346846686373277921L, UTF8String.fromString("revenue"), UTF8String.fromString("7.75E8"), UTF8String.fromString("double")),
+      InternalRow(-6346846686373277921L, UTF8String.fromString("running_time"), UTF8String.fromString("121"), UTF8String.fromString("long")),
+      InternalRow(-6346846686373277921L, UTF8String.fromString("starring"), UTF8String.fromString("3100520392254949455"), UTF8String.fromString("uid")),
+      InternalRow(-6346846686373277921L, UTF8String.fromString("starring"), UTF8String.fromString("999257064750498476"), UTF8String.fromString("uid")),
+      InternalRow(-6346846686373277921L, UTF8String.fromString("starring"), UTF8String.fromString("-1877623327044447073"), UTF8String.fromString("uid")),
+      InternalRow(-6346846686373277921L, UTF8String.fromString("director"), UTF8String.fromString("8214320560726473464"), UTF8String.fromString("uid")),
+    ))
   }
 
 }

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/encoder/TestTypedNodeEncoder.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/encoder/TestTypedNodeEncoder.scala
@@ -71,122 +71,6 @@ class TestTypedNodeEncoder extends AnyFunSpec {
     }
 
     it("should parse JSON response") {
-      val schema = Schema(Set(
-        Predicate("name", "string"),
-        Predicate("release_date", "datetime"),
-        Predicate("revenue", "float"),
-        Predicate("running_time", "int"),
-        Predicate("director", "uid"),
-        Predicate("starring", "uid")
-      ))
-
-      val json =
-        """
-          |{
-          |    "result": [
-          |      {
-          |        "uid": "0x1",
-          |        "name": "Star Wars: Episode IV - A New Hope",
-          |        "release_date": "1977-05-25T00:00:00Z",
-          |        "revenue": "775000000",
-          |        "running_time": 121,
-          |        "starring": [
-          |          {
-          |            "uid": "0x2"
-          |          },
-          |          {
-          |            "uid": "0x3"
-          |          },
-          |          {
-          |            "uid": "0x7"
-          |          }
-          |        ],
-          |        "director": [
-          |          {
-          |            "uid": "0x4"
-          |          }
-          |        ]
-          |      },
-          |      {
-          |        "uid": "0x2",
-          |        "name": "Luke Skywalker"
-          |      },
-          |      {
-          |        "uid": "0x3",
-          |        "name": "Han Solo"
-          |      },
-          |      {
-          |        "uid": "0x4",
-          |        "name": "George Lucas"
-          |      },
-          |      {
-          |        "uid": "0x5",
-          |        "name": "Irvin Kernshner"
-          |      },
-          |      {
-          |        "uid": "0x6",
-          |        "name": "Richard Marquand"
-          |      },
-          |      {
-          |        "uid": "0x7",
-          |        "name": "Princess Leia"
-          |      },
-          |      {
-          |        "uid": "0x8",
-          |        "name": "Star Wars: Episode V - The Empire Strikes Back",
-          |        "release_date": "1980-05-21T00:00:00Z",
-          |        "revenue": "534000000",
-          |        "running_time": 124,
-          |        "starring": [
-          |          {
-          |            "uid": "0x2"
-          |          },
-          |          {
-          |            "uid": "0x3"
-          |          },
-          |          {
-          |            "uid": "0x7"
-          |          }
-          |        ],
-          |        "director": [
-          |          {
-          |            "uid": "0x5"
-          |          }
-          |        ]
-          |      },
-          |      {
-          |        "uid": "0x9",
-          |        "name": "Star Wars: Episode VI - Return of the Jedi",
-          |        "release_date": "1983-05-25T00:00:00Z",
-          |        "revenue": "572000000",
-          |        "running_time": 131,
-          |        "starring": [
-          |          {
-          |            "uid": "0x2"
-          |          },
-          |          {
-          |            "uid": "0x3"
-          |          },
-          |          {
-          |            "uid": "0x7"
-          |          }
-          |        ],
-          |        "director": [
-          |          {
-          |            "uid": "0x6"
-          |          }
-          |        ]
-          |      },
-          |      {
-          |        "uid": "0xa",
-          |        "name": "Star Trek: The Motion Picture",
-          |        "release_date": "1979-12-07T00:00:00Z",
-          |        "revenue": "139000000",
-          |        "running_time": 132
-          |      }
-          |    ]
-          |  }""".stripMargin
-
       def ts(string: String): Long = DateTimeUtils.fromJavaTimestamp(Timestamp.valueOf(string))
 
       val encoder = TypedNodeEncoder(schema.predicateMap)
@@ -217,6 +101,18 @@ class TestTypedNodeEncoder extends AnyFunSpec {
       ))
     }
 
+    it("should parse JSON response with large uids") {
+      def ts(string: String): Long = DateTimeUtils.fromJavaTimestamp(Timestamp.valueOf(string))
+
+      val encoder = TypedNodeEncoder(schema.predicateMap)
+      val rows = encoder.fromJson(Json(jsonWithLargeUids), "result")
+      assert(rows.toSeq === Seq(
+        InternalRow(-6346846686373277921L, UTF8String.fromString("name"), UTF8String.fromString("Star Wars: Episode IV - A New Hope"), null, null, null, null, null, null, UTF8String.fromString("string")),
+        InternalRow(-6346846686373277921L, UTF8String.fromString("release_date"), null, null, null, ts("1977-05-25 00:00:00"), null, null, null, UTF8String.fromString("timestamp")),
+        InternalRow(-6346846686373277921L, UTF8String.fromString("revenue"), null, null, 775000000.0, null, null, null, null, UTF8String.fromString("double")),
+        InternalRow(-6346846686373277921L, UTF8String.fromString("running_time"), null, 121L, null, null, null, null, null, UTF8String.fromString("long")),
+      ))
+    }
   }
 
 }

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/encoder/TestTypedTripleEncoder.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/encoder/TestTypedTripleEncoder.scala
@@ -103,122 +103,6 @@ class TestTypedTripleEncoder extends AnyFunSpec {
   }
 
   it("should parse JSON response") {
-    val schema = Schema(Set(
-      Predicate("name", "string"),
-      Predicate("release_date", "datetime"),
-      Predicate("revenue", "float"),
-      Predicate("running_time", "int"),
-      Predicate("director", "uid"),
-      Predicate("starring", "uid")
-    ))
-
-    val json =
-      """
-        |{
-        |    "result": [
-        |      {
-        |        "uid": "0x1",
-        |        "name": "Star Wars: Episode IV - A New Hope",
-        |        "release_date": "1977-05-25T00:00:00Z",
-        |        "revenue": "775000000",
-        |        "running_time": 121,
-        |        "starring": [
-        |          {
-        |            "uid": "0x2"
-        |          },
-        |          {
-        |            "uid": "0x3"
-        |          },
-        |          {
-        |            "uid": "0x7"
-        |          }
-        |        ],
-        |        "director": [
-        |          {
-        |            "uid": "0x4"
-        |          }
-        |        ]
-        |      },
-        |      {
-        |        "uid": "0x2",
-        |        "name": "Luke Skywalker"
-        |      },
-        |      {
-        |        "uid": "0x3",
-        |        "name": "Han Solo"
-        |      },
-        |      {
-        |        "uid": "0x4",
-        |        "name": "George Lucas"
-        |      },
-        |      {
-        |        "uid": "0x5",
-        |        "name": "Irvin Kernshner"
-        |      },
-        |      {
-        |        "uid": "0x6",
-        |        "name": "Richard Marquand"
-        |      },
-        |      {
-        |        "uid": "0x7",
-        |        "name": "Princess Leia"
-        |      },
-        |      {
-        |        "uid": "0x8",
-        |        "name": "Star Wars: Episode V - The Empire Strikes Back",
-        |        "release_date": "1980-05-21T00:00:00Z",
-        |        "revenue": "534000000",
-        |        "running_time": 124,
-        |        "starring": [
-        |          {
-        |            "uid": "0x2"
-        |          },
-        |          {
-        |            "uid": "0x3"
-        |          },
-        |          {
-        |            "uid": "0x7"
-        |          }
-        |        ],
-        |        "director": [
-        |          {
-        |            "uid": "0x5"
-        |          }
-        |        ]
-        |      },
-        |      {
-        |        "uid": "0x9",
-        |        "name": "Star Wars: Episode VI - Return of the Jedi",
-        |        "release_date": "1983-05-25T00:00:00Z",
-        |        "revenue": "572000000",
-        |        "running_time": 131,
-        |        "starring": [
-        |          {
-        |            "uid": "0x2"
-        |          },
-        |          {
-        |            "uid": "0x3"
-        |          },
-        |          {
-        |            "uid": "0x7"
-        |          }
-        |        ],
-        |        "director": [
-        |          {
-        |            "uid": "0x6"
-        |          }
-        |        ]
-        |      },
-        |      {
-        |        "uid": "0xa",
-        |        "name": "Star Trek: The Motion Picture",
-        |        "release_date": "1979-12-07T00:00:00Z",
-        |        "revenue": "139000000",
-        |        "running_time": 132
-        |      }
-        |    ]
-        |  }""".stripMargin
-
     def ts(string: String): Long = DateTimeUtils.fromJavaTimestamp(Timestamp.valueOf(string))
 
     val encoder = TypedTripleEncoder(schema.predicateMap)
@@ -258,6 +142,23 @@ class TestTypedTripleEncoder extends AnyFunSpec {
       InternalRow(10L, UTF8String.fromString("release_date"), null, null, null, null, ts("1979-12-07 00:00:00"), null, null, null, UTF8String.fromString("timestamp")),
       InternalRow(10L, UTF8String.fromString("revenue"), null, null, null, 139000000.0, null, null, null, null, UTF8String.fromString("double")),
       InternalRow(10L, UTF8String.fromString("running_time"), null, null, 132L, null, null, null, null, null, UTF8String.fromString("long")),
+    ))
+  }
+
+  it("should parse JSON response with larg euids") {
+    def ts(string: String): Long = DateTimeUtils.fromJavaTimestamp(Timestamp.valueOf(string))
+
+    val encoder = TypedTripleEncoder(schema.predicateMap)
+    val rows = encoder.fromJson(Json(jsonWithLargeUids), "result")
+    assert(rows.toSeq === Seq(
+      InternalRow(-6346846686373277921L, UTF8String.fromString("name"), null, UTF8String.fromString("Star Wars: Episode IV - A New Hope"), null, null, null, null, null, null, UTF8String.fromString("string")),
+      InternalRow(-6346846686373277921L, UTF8String.fromString("release_date"), null, null, null, null, ts("1977-05-25 00:00:00"), null, null, null, UTF8String.fromString("timestamp")),
+      InternalRow(-6346846686373277921L, UTF8String.fromString("revenue"), null, null, null, 775000000.0, null, null, null, null, UTF8String.fromString("double")),
+      InternalRow(-6346846686373277921L, UTF8String.fromString("running_time"), null, null, 121L, null, null, null, null, null, UTF8String.fromString("long")),
+      InternalRow(-6346846686373277921L, UTF8String.fromString("starring"), 3100520392254949455L, null, null, null, null, null, null, null, UTF8String.fromString("uid")),
+      InternalRow(-6346846686373277921L, UTF8String.fromString("starring"), 999257064750498476L, null, null, null, null, null, null, null, UTF8String.fromString("uid")),
+      InternalRow(-6346846686373277921L, UTF8String.fromString("starring"), -1877623327044447073L, null, null, null, null, null, null, null, UTF8String.fromString("uid")),
+      InternalRow(-6346846686373277921L, UTF8String.fromString("director"), 8214320560726473464L, null, null, null, null, null, null, null, UTF8String.fromString("uid")),
     ))
   }
 

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/encoder/TestTypedTripleEncoder.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/encoder/TestTypedTripleEncoder.scala
@@ -53,7 +53,7 @@ class TestTypedTripleEncoder extends AnyFunSpec {
       assert(row.numFields === 11)
       assert(row.getLong(0) === 1)
       assert(row.getString(1) === "predicate")
-      if (encType == "uid") assert(row.getLong(2) === value.asInstanceOf[Uid].uid) else assert(row.get(2, StringType) === null)
+      if (encType == "uid") assert(row.getLong(2) === value.asInstanceOf[Uid].uid.longValue()) else assert(row.get(2, StringType) === null)
       if (encType == "string" || encType == "default") assert(row.getUTF8String(3).toString === value.toString) else assert(row.get(3, StringType) === null)
       if (encType == "int") assert(row.getLong(4) === value) else assert(row.get(4, StringType) === null)
       if (encType == "float") assert(row.getDouble(5) === value) else assert(row.get(5, StringType) === null)

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/encoder/TestWideNodeEncoder.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/encoder/TestWideNodeEncoder.scala
@@ -120,112 +120,6 @@ class TestWideNodeEncoder extends AnyFunSpec {
         |    ]
         |  }""".stripMargin
 
-    val fullJsonWithEdges =
-      """{
-        |    "result": [
-        |      {
-        |        "uid": "0x1",
-        |        "name": "Star Wars: Episode IV - A New Hope",
-        |        "release_date": "1977-05-25T00:00:00Z",
-        |        "revenue": "775000000",
-        |        "running_time": 121,
-        |        "starring": [
-        |          {
-        |            "uid": "0x2"
-        |          },
-        |          {
-        |            "uid": "0x3"
-        |          },
-        |          {
-        |            "uid": "0x7"
-        |          }
-        |        ],
-        |        "director": [
-        |          {
-        |            "uid": "0x4"
-        |          }
-        |        ]
-        |      },
-        |      {
-        |        "uid": "0x2",
-        |        "name": "Luke Skywalker"
-        |      },
-        |      {
-        |        "uid": "0x3",
-        |        "name": "Han Solo"
-        |      },
-        |      {
-        |        "uid": "0x4",
-        |        "name": "George Lucas"
-        |      },
-        |      {
-        |        "uid": "0x5",
-        |        "name": "Irvin Kernshner"
-        |      },
-        |      {
-        |        "uid": "0x6",
-        |        "name": "Richard Marquand"
-        |      },
-        |      {
-        |        "uid": "0x7",
-        |        "name": "Princess Leia"
-        |      },
-        |      {
-        |        "uid": "0x8",
-        |        "name": "Star Wars: Episode V - The Empire Strikes Back",
-        |        "release_date": "1980-05-21T00:00:00Z",
-        |        "revenue": "534000000",
-        |        "running_time": 124,
-        |        "starring": [
-        |          {
-        |            "uid": "0x2"
-        |          },
-        |          {
-        |            "uid": "0x3"
-        |          },
-        |          {
-        |            "uid": "0x7"
-        |          }
-        |        ],
-        |        "director": [
-        |          {
-        |            "uid": "0x5"
-        |          }
-        |        ]
-        |      },
-        |      {
-        |        "uid": "0x9",
-        |        "name": "Star Wars: Episode VI - Return of the Jedi",
-        |        "release_date": "1983-05-25T00:00:00Z",
-        |        "revenue": "572000000",
-        |        "running_time": 131,
-        |        "starring": [
-        |          {
-        |            "uid": "0x2"
-        |          },
-        |          {
-        |            "uid": "0x3"
-        |          },
-        |          {
-        |            "uid": "0x7"
-        |          }
-        |        ],
-        |        "director": [
-        |          {
-        |            "uid": "0x6"
-        |          }
-        |        ]
-        |      },
-        |      {
-        |        "uid": "0xa",
-        |        "name": "Star Trek: The Motion Picture",
-        |        "release_date": "1979-12-07T00:00:00Z",
-        |        "revenue": "139000000",
-        |        "running_time": 132
-        |      }
-        |    ]
-        |  }""".stripMargin
-
     // only name, release_date and director selected
     val projectedJsonWithEdges =
       """{
@@ -351,8 +245,18 @@ class TestWideNodeEncoder extends AnyFunSpec {
     }
 
     it("should parse JSON response and ignore edges") {
-      val rows = encoder.fromJson(Json(fullJsonWithEdges), "result").toSeq
+      val rows = encoder.fromJson(Json(json), "result").toSeq
       assert(rows === expectedRowsFullSchema)
+      assert(encoder.schema === expectedSchema)
+      assert(encoder.readSchema === expectedSchema)
+    }
+
+    it("should parse JSON response with large uids") {
+      val rows = encoder.fromJson(Json(jsonWithLargeUids), "result").toSeq
+      val expected = Seq(
+        InternalRow(-6346846686373277921L, UTF8String.fromString("Star Wars: Episode IV - A New Hope"), ts("1977-05-25 00:00:00"), 7.75E8, 121),
+      )
+      assert(rows === expected)
       assert(encoder.schema === expectedSchema)
       assert(encoder.readSchema === expectedSchema)
     }

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/encoder/package.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/encoder/package.scala
@@ -1,0 +1,147 @@
+package uk.co.gresearch.spark.dgraph.connector
+
+package object encoder {
+  val schema: Schema = Schema(Set(
+    Predicate("name", "string"),
+    Predicate("release_date", "datetime"),
+    Predicate("revenue", "float"),
+    Predicate("running_time", "int"),
+    Predicate("director", "uid"),
+    Predicate("starring", "uid")
+  ))
+
+  val json: String =
+    """{
+      |    "result": [
+      |      {
+      |        "uid": "0x1",
+      |        "name": "Star Wars: Episode IV - A New Hope",
+      |        "release_date": "1977-05-25T00:00:00Z",
+      |        "revenue": "775000000",
+      |        "running_time": 121,
+      |        "starring": [
+      |          {
+      |            "uid": "0x2"
+      |          },
+      |          {
+      |            "uid": "0x3"
+      |          },
+      |          {
+      |            "uid": "0x7"
+      |          }
+      |        ],
+      |        "director": [
+      |          {
+      |            "uid": "0x4"
+      |          }
+      |        ]
+      |      },
+      |      {
+      |        "uid": "0x2",
+      |        "name": "Luke Skywalker"
+      |      },
+      |      {
+      |        "uid": "0x3",
+      |        "name": "Han Solo"
+      |      },
+      |      {
+      |        "uid": "0x4",
+      |        "name": "George Lucas"
+      |      },
+      |      {
+      |        "uid": "0x5",
+      |        "name": "Irvin Kernshner"
+      |      },
+      |      {
+      |        "uid": "0x6",
+      |        "name": "Richard Marquand"
+      |      },
+      |      {
+      |        "uid": "0x7",
+      |        "name": "Princess Leia"
+      |      },
+      |      {
+      |        "uid": "0x8",
+      |        "name": "Star Wars: Episode V - The Empire Strikes Back",
+      |        "release_date": "1980-05-21T00:00:00Z",
+      |        "revenue": "534000000",
+      |        "running_time": 124,
+      |        "starring": [
+      |          {
+      |            "uid": "0x2"
+      |          },
+      |          {
+      |            "uid": "0x3"
+      |          },
+      |          {
+      |            "uid": "0x7"
+      |          }
+      |        ],
+      |        "director": [
+      |          {
+      |            "uid": "0x5"
+      |          }
+      |        ]
+      |      },
+      |      {
+      |        "uid": "0x9",
+      |        "name": "Star Wars: Episode VI - Return of the Jedi",
+      |        "release_date": "1983-05-25T00:00:00Z",
+      |        "revenue": "572000000",
+      |        "running_time": 131,
+      |        "starring": [
+      |          {
+      |            "uid": "0x2"
+      |          },
+      |          {
+      |            "uid": "0x3"
+      |          },
+      |          {
+      |            "uid": "0x7"
+      |          }
+      |        ],
+      |        "director": [
+      |          {
+      |            "uid": "0x6"
+      |          }
+      |        ]
+      |      },
+      |      {
+      |        "uid": "0xa",
+      |        "name": "Star Trek: The Motion Picture",
+      |        "release_date": "1979-12-07T00:00:00Z",
+      |        "revenue": "139000000",
+      |        "running_time": 132
+      |      }
+      |    ]
+      |  }""".stripMargin
+
+  val jsonWithLargeUids: String =
+    """{
+      |    "result": [
+      |      {
+      |        "uid": "0xa7eb7890d6db0f1f",
+      |        "name": "Star Wars: Episode IV - A New Hope",
+      |        "release_date": "1977-05-25T00:00:00Z",
+      |        "revenue": "775000000",
+      |        "running_time": 121,
+      |        "starring": [
+      |          {
+      |            "uid": "0x2b0742de9736084f"
+      |          },
+      |          {
+      |            "uid": "0xdde13018fc0c2ac"
+      |          },
+      |          {
+      |            "uid": "0xe5f157883987549f"
+      |          }
+      |        ],
+      |        "director": [
+      |          {
+      |            "uid": "0x71ff21075549faf8"
+      |          }
+      |        ]
+      |      }
+      |    ]
+      |  }""".stripMargin
+}

--- a/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestUidCardinalityEstimator.scala
+++ b/src/test/scala/uk/co/gresearch/spark/dgraph/connector/partitioner/TestUidCardinalityEstimator.scala
@@ -30,7 +30,7 @@ class TestUidCardinalityEstimator extends AnyFunSpec {
       val partition = Partition(Seq.empty, Set(range))
       val actual = estimator.uidCardinality(partition)
       assert(actual.isDefined === true)
-      assert(actual.get.intValue() === range.length)
+      assert(actual.get.intValue() === range.length.intValue())
     }
 
     it("should estimate partition's uids cardinality") {


### PR DESCRIPTION
Dgraph's uids are unsigned long (64 bit) while Scala and Spark only support signed long. Uids are read and internally represented as unsigned longs and stored in DataFrames as signed longs. The upper half of the value range is therefore represented by negative longs, which is consistent as order of uids does not matter in the graph.

This allows to read graphs inserted by the Dgraph live loader, which produces uids in the upper half of the value range.