### PR TITLE
Handle default data type as string

### DIFF
--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/encoder/JsonNodeInternalRowEncoder.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/encoder/JsonNodeInternalRowEncoder.scala
@@ -115,7 +115,7 @@ trait JsonNodeInternalRowEncoder extends InternalRowEncoder with Logging {
       case "bool" | "boolean" => value.getAsString == "true"
       case "geo" => Geo(value.getAsJsonObject.toString)
       case "password" => Password(value.getAsJsonObject.getAsString)
-      case "default" => value.getAsJsonObject.getAsString
+      case "default" => value.getAsString
       case _ => value.getAsString
     }
 

--- a/src/main/scala/uk/co/gresearch/spark/dgraph/connector/encoder/JsonNodeInternalRowEncoder.scala
+++ b/src/main/scala/uk/co/gresearch/spark/dgraph/connector/encoder/JsonNodeInternalRowEncoder.scala
@@ -105,7 +105,7 @@ trait JsonNodeInternalRowEncoder extends InternalRowEncoder with Logging {
     valueType match {
       // the uid of a node, the subject of a triple
       case "subject" => Uid(value.getAsString)
-      // https://dgraph.io/docs/query-language/#schema-types
+      // https://dgraph.io/docs/dql/predicate-types/#scalar-types
       case "uid" => Uid(value.getAsJsonObject.get("uid").getAsString)
       case "string" => value.getAsString
       case "int" | "long" => value.getAsLong


### PR DESCRIPTION
Values of data type "default" should be handled as plain strings: https://dgraph.io/docs/dql/predicate-types/#scalar-types