### PR TITLE
638 spark dgraph connector GitHub deprecation  warnings

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -26,14 +26,14 @@ runs:
       shell: bash
 
     - name: Cache Maven packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-compat-version }}-${{ hashFiles('pom.xml') }}
         restore-keys: ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-compat-version }}-
 
     - name: Setup JDK 1.11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '11'
         distribution: 'zulu'
@@ -46,7 +46,7 @@ runs:
       shell: bash
 
     - name: Upload Binaries
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Binaries-${{ inputs.spark-compat-version }}-${{ inputs.scala-compat-version }}
         path: |

--- a/.github/actions/test-integrate/action.yml
+++ b/.github/actions/test-integrate/action.yml
@@ -32,13 +32,13 @@ runs:
       shell: bash
 
     - name: Fetch Binaries Artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: Binaries-${{ inputs.spark-compat-version }}-${{ inputs.scala-compat-version }}
         path: .
 
     - name: Cache Maven packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-mvn-integrate-${{ inputs.spark-version }}-${{ inputs.scala-compat-version }}-${{ hashFiles('pom.xml') }}
@@ -47,7 +47,7 @@ runs:
           ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-compat-version }}-
 
     - name: Cache Spark Binaries
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/spark
         key: ${{ runner.os }}-spark-binaries-${{ inputs.spark-version }}-${{ inputs.scala-compat-version }}

--- a/.github/actions/test-python/action.yml
+++ b/.github/actions/test-python/action.yml
@@ -32,13 +32,13 @@ runs:
       shell: bash
 
     - name: Fetch Binaries Artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: Binaries-${{ inputs.spark-compat-version }}-${{ inputs.scala-compat-version }}
         path: .
 
     - name: Cache Maven packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-mvn-python-test-${{ inputs.spark-version }}-${{ inputs.scala-compat-version }}-${{ hashFiles('pom.xml') }}
@@ -48,7 +48,7 @@ runs:
           ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-compat-version }}-
 
     - name: Setup JDK 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '11'
         distribution: 'zulu'
@@ -70,7 +70,7 @@ runs:
       shell: bash
 
     - name: Cache Pip packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-test-${{ inputs.python-version }}-${{ inputs.spark-version }}-${{ hashFiles('**/requirements.txt') }}
@@ -78,7 +78,7 @@ runs:
           ${{ runner.os }}-pip-test-${{ inputs.python-version }}-${{ inputs.spark-version }}-
 
     - name: Setup Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
 
@@ -100,7 +100,7 @@ runs:
 
     - name: Upload Unit Test Results
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Unit Test Results (Spark ${{ inputs.spark-version }}, Scala ${{ inputs.scala-version}}, Dgraph ${{ inputs.dgraph-version }}, Python ${{ inputs.python-version }})
         path: |

--- a/.github/actions/test-scala/action.yml
+++ b/.github/actions/test-scala/action.yml
@@ -29,13 +29,13 @@ runs:
       shell: bash
 
     - name: Fetch Binaries Artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: Binaries-${{ inputs.spark-compat-version }}-${{ inputs.scala-compat-version }}
         path: .
 
     - name: Cache Maven packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-mvn-test-${{ inputs.spark-version }}-${{ inputs.scala-compat-version }}-${{ hashFiles('pom.xml') }}
@@ -44,7 +44,7 @@ runs:
           ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-compat-version }}-
 
     - name: Setup JDK 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '11'
         distribution: 'zulu'
@@ -78,7 +78,7 @@ runs:
 
     - name: Upload Unit Test Results
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Unit Test Results (Spark ${{ inputs.spark-version }}, Scala ${{ inputs.scala-version}}, Dgraph ${{ inputs.dgraph-version }})
         path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Build
 
 on:
   workflow_call:
+  pull_request:
 
 jobs:
   build:
@@ -56,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         uses: ./.github/actions/build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ name: Build
 
 on:
   workflow_call:
-  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Event File
           path: ${{ github.event_path }}
@@ -169,6 +169,6 @@ jobs:
     needs: [test-dgraph, test-spark, test-scala, test-python, test-integration]
     steps:
       - name: Delete Binaries Artifact
-        uses: geekyeggo/delete-artifact@v2
+        uses: geekyeggo/delete-artifact@v5
         with:
           name: "Binaries-*"

--- a/.github/workflows/test-dgraph.yml
+++ b/.github/workflows/test-dgraph.yml
@@ -2,7 +2,6 @@ name: Test Dgraph
 
 on:
   workflow_call:
-  pull_request:
 
 jobs:
   test-dgraph:

--- a/.github/workflows/test-dgraph.yml
+++ b/.github/workflows/test-dgraph.yml
@@ -2,6 +2,7 @@ name: Test Dgraph
 
 on:
   workflow_call:
+  pull_request:
 
 jobs:
   test-dgraph:
@@ -30,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Test
         uses: ./.github/actions/test-scala

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -2,7 +2,6 @@ name: Test Integration
 
 on:
   workflow_call:
-  pull_request:
 
 jobs:
   test-integration:

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -2,6 +2,7 @@ name: Test Integration
 
 on:
   workflow_call:
+  pull_request:
 
 jobs:
   test-integration:
@@ -69,7 +70,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Test
         uses: ./.github/actions/test-integrate

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -2,6 +2,7 @@ name: Test Python
 
 on:
   workflow_call:
+  pull_request:
 
 jobs:
   test-python:
@@ -32,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Test
         uses: ./.github/actions/test-python

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -2,7 +2,6 @@ name: Test Python
 
 on:
   workflow_call:
-  pull_request:
 
 jobs:
   test-python:

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -5,13 +5,12 @@ on:
     workflows: ["CI"]
     types:
       - completed
-  pull_request:
 
 jobs:
   test-results:
     name: Test Results
     runs-on: ubuntu-latest
-    # if: github.event.workflow_run.conclusion != 'skipped'
+    if: github.event.workflow_run.conclusion != 'skipped'
 
     steps:
       - name: Download and Extract Artifacts

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -5,16 +5,17 @@ on:
     workflows: ["CI"]
     types:
       - completed
+  pull_request:
 
 jobs:
   test-results:
     name: Test Results
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion != 'skipped'
+    # if: github.event.workflow_run.conclusion != 'skipped'
 
     steps:
       - name: Download and Extract Artifacts
-        uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615
+        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe
         with:
           run_id: ${{ github.event.workflow_run.id }}
           name: "Unit Test Results |Event File"

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -11,6 +11,9 @@ jobs:
     name: Test Results
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion != 'skipped'
+    permissions:
+      checks: write
+      pull-requests: write
 
     steps:
       - name: Download and Extract Artifacts

--- a/.github/workflows/test-scala.yml
+++ b/.github/workflows/test-scala.yml
@@ -6,7 +6,6 @@ on:
       matrix:
         required: true
         type: string
-  pull_request:
 
 jobs:
   test-spark:

--- a/.github/workflows/test-scala.yml
+++ b/.github/workflows/test-scala.yml
@@ -6,6 +6,7 @@ on:
       matrix:
         required: true
         type: string
+  pull_request:
 
 jobs:
   test-spark:
@@ -18,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Test
         uses: ./.github/actions/test-scala

--- a/.github/workflows/test-spark.yml
+++ b/.github/workflows/test-spark.yml
@@ -6,6 +6,7 @@ on:
       dgraph-version:
         required: true
         type: string
+  pull_request:
 
 jobs:
   test-spark:
@@ -92,7 +93,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Test
         uses: ./.github/actions/test-scala

--- a/.github/workflows/test-spark.yml
+++ b/.github/workflows/test-spark.yml
@@ -6,7 +6,6 @@ on:
       dgraph-version:
         required: true
         type: string
-  pull_request:
 
 jobs:
   test-spark:


### PR DESCRIPTION
### What type of PR is this?

CI: Resolve deprecation & warning messages in workflows 
Enable DependaBot for GitHub actions

### What this PR does / why we need it:

Node16 has been out of support since [September 2023](https://github.com/nodejs/Release/#end-of-life-releases). - more info in the [post](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/) 

- Fix CI warnings/deprecations in used action (commit)

### Which issue(s) this PR fixes:

Resolves: https://github.com/G-Research/gr-oss/issues/638

------------

## Testing results

### PASSED 🟢 

**Build**
 - https://github.com/gr-oss-devops/spark-dgraph-connector/actions/runs/8536832046/job/23386177490?pr=1

**CI** 
 - https://github.com/gr-oss-devops/spark-dgraph-connector/actions/runs/8536832055/job/23386179754?pr=1

**Test Dgraph** 
 - https://github.com/gr-oss-devops/spark-dgraph-connector/actions/runs/8536832039/job/23386177489?pr=1
__NOTE__ this workflow is not executed on [upstream](https://github.com/G-Research/spark-dgraph-connector/actions/workflows/test-dgraph.yml) 

**Test Integration**
 - https://github.com/gr-oss-devops/spark-dgraph-connector/actions/runs/8783884380/job/24103201660?pr=1

**Test Python**
 - https://github.com/gr-oss-devops/spark-dgraph-connector/actions/runs/8783884380/job/24103201660?pr=1

**Test Results**
 - https://github.com/gr-oss-devops/spark-dgraph-connector/actions/runs/8877788146
