### PR TITLE
Fix spark version in workflow job names

### DIFF
--- a/.github/workflows/test-dgraph.yml
+++ b/.github/workflows/test-dgraph.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   test-dgraph:
-    name: Unit Tests (Dgraph ${{ matrix.dgraph-version }} Spark ${{ matrix.spark-compat-version }}.${{ matrix.spark-patch-version }} Scala ${{ matrix.scala-compat-version }})
+    name: Unit Tests (Dgraph ${{ matrix.dgraph-version }} Spark ${{ matrix.spark-compat-version }} Scala ${{ matrix.scala-compat-version }})
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/test-spark.yml
+++ b/.github/workflows/test-spark.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test-spark:
-    name: Unit Tests (Spark ${{ matrix.spark-compat-version }}.${{ matrix.spark-patch-version }} Scala ${{ matrix.scala-compat-version }})
+    name: Unit Tests (Spark ${{ matrix.spark-version }} Scala ${{ matrix.scala-compat-version }})
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
## Checklist before submitting

- [X] Did you read the [contributing guide](https://github.com/G-Research/spark-dgraph-connector/blob/contributing-guidelines/CONTRIBUTING.md)?
- [X] Did you update the docs?
- [X] Did you write any tests to validate this change?  

## Description

Job names in some workflows contain Spark patch version, which is not available. This fixes names.

## Review process for approval

1. All tests and other checks must succeed.
2. At least one core contributors must review and approve.
3. If a core contributor requests changes, they must be addressed.