### PR TITLE
CI: Remove EOL Spark patch versions except for latest

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        spark-compat-version: ["3.2", "3.3", "3.4", "3.5"]
+        spark-compat-version: ["3.4", "3.5"]
         dgraph-minor-version: ["20.03", "20.07", "20.11", "21.12", "22.0", "23.0", "23.1", "24.0"]
         scala-compat-version: ["2.12"]
         include:
@@ -35,12 +35,18 @@ jobs:
             spark-version: '3.2.4'
             scala-compat-version: '2.12'
             scala-version: '2.12.15'
+            dgraph-minor-version: "22.0"
+            dgraph-version: "22.0.2"
             hadoop-version: '2.7'
+
           - spark-compat-version: '3.3'
             spark-version: '3.3.4'
             scala-compat-version: '2.12'
             scala-version: '2.12.15'
+            dgraph-minor-version: "22.0"
+            dgraph-version: "22.0.2"
             hadoop-version: '3'
+
           - spark-compat-version: '3.4'
             spark-version: '3.4.3'
             scala-compat-version: '2.12'

--- a/.github/workflows/test-spark.yml
+++ b/.github/workflows/test-spark.yml
@@ -16,10 +16,12 @@ jobs:
       fail-fast: false
       matrix:
         spark-version: [
+            # we test latest patch version of EOL minor releases
             "3.0.3",
             "3.1.3",
-            "3.2.0", "3.2.1", "3.2.2", "3.2.3", "3.2.4",
-            "3.3.0", "3.3.1", "3.3.2", "3.3.3", "3.3.4",
+            "3.2.4",
+            "3.3.4",
+            # we test all patch version of current supported minor releases
             "3.4.0", "3.4.1", "3.4.2"
             # latest spark version tested in test-dgraph, not testes here again
         ]
@@ -35,43 +37,11 @@ jobs:
             scala-compat-version: "2.12"
             scala-version: "2.12.10"
 
-          - spark-version: "3.2.0"
-            spark-compat-version: "3.2"
-            scala-compat-version: "2.12"
-            scala-version: "2.12.15"
-          - spark-version: "3.2.1"
-            spark-compat-version: "3.2"
-            scala-compat-version: "2.12"
-            scala-version: "2.12.15"
-          - spark-version: "3.2.2"
-            spark-compat-version: "3.2"
-            scala-compat-version: "2.12"
-            scala-version: "2.12.15"
-          - spark-version: "3.2.3"
-            spark-compat-version: "3.2"
-            scala-compat-version: "2.12"
-            scala-version: "2.12.15"
           - spark-version: "3.2.4"
             spark-compat-version: "3.2"
             scala-compat-version: "2.12"
             scala-version: "2.12.15"
 
-          - spark-version: "3.3.0"
-            spark-compat-version: "3.3"
-            scala-compat-version: "2.12"
-            scala-version: "2.12.15"
-          - spark-version: "3.3.1"
-            spark-compat-version: "3.3"
-            scala-compat-version: "2.12"
-            scala-version: "2.12.15"
-          - spark-version: "3.3.2"
-            spark-compat-version: "3.3"
-            scala-compat-version: "2.12"
-            scala-version: "2.12.15"
-          - spark-version: "3.3.3"
-            spark-compat-version: "3.3"
-            scala-compat-version: "2.12"
-            scala-version: "2.12.15"
           - spark-version: "3.3.4"
             spark-compat-version: "3.3"
             scala-compat-version: "2.12"


### PR DESCRIPTION
Test only latest Spark patch version of EOL minor versions.