### PR TITLE
GROSS-1358: SHA-pin GitHub Actions

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -29,14 +29,14 @@ runs:
       shell: bash
 
     - name: Cache Maven packages
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-compat-version }}-${{ hashFiles('pom.xml') }}
         restore-keys: ${{ runner.os }}-mvn-build-${{ inputs.spark-version }}-${{ inputs.scala-compat-version }}-
 
     - name: Setup JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
       with:
         java-version: ${{ inputs.java-version }}
         distribution: 'zulu'
@@ -53,7 +53,7 @@ runs:
       shell: bash
 
     - name: Upload Binaries
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: Binaries-${{ inputs.spark-compat-version }}-${{ inputs.scala-compat-version }}
         path: |
@@ -63,7 +63,7 @@ runs:
           !target/site
 
     - name: Upload Dependencies
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: Dependencies-${{ inputs.spark-compat-version }}-${{ inputs.scala-compat-version }}
         path: ~/.m2/repository

--- a/.github/actions/test-integrate/action.yml
+++ b/.github/actions/test-integrate/action.yml
@@ -35,19 +35,19 @@ runs:
       shell: bash
 
     - name: Fetch Binaries Artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: Binaries-${{ inputs.spark-compat-version }}-${{ inputs.scala-compat-version }}
         path: .
 
     - name: Fetch Dependencies Artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: Dependencies-${{ inputs.spark-compat-version }}-${{ inputs.scala-compat-version }}
         path: ~/.m2/repository
 
     - name: Fetch Spark Binaries Artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: Spark-Binaries-${{ inputs.spark-version }}-${{ inputs.hadoop-version }}
         path: ~/spark
@@ -57,7 +57,7 @@ runs:
       shell: bash
 
     - name: Setup JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
       with:
         java-version: ${{ inputs.java-version }}
         distribution: 'zulu'

--- a/.github/actions/test-python/action.yml
+++ b/.github/actions/test-python/action.yml
@@ -32,19 +32,19 @@ runs:
       shell: bash
 
     - name: Fetch Binaries Artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: Binaries-${{ inputs.spark-compat-version }}-${{ inputs.scala-compat-version }}
         path: .
 
     - name: Fetch Dependencies Artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: Dependencies-${{ inputs.spark-compat-version }}-${{ inputs.scala-compat-version }}
         path: ~/.m2/repository
 
     - name: Setup JDK 11
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
       with:
         java-version: '11'
         distribution: 'zulu'
@@ -66,7 +66,7 @@ runs:
       shell: bash
 
     - name: Cache Pip packages
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-test-${{ inputs.python-version }}-${{ inputs.spark-version }}-${{ hashFiles('**/requirements.txt') }}
@@ -74,7 +74,7 @@ runs:
           ${{ runner.os }}-pip-test-${{ inputs.python-version }}-${{ inputs.spark-version }}-
 
     - name: Setup Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: ${{ inputs.python-version }}
 
@@ -96,7 +96,7 @@ runs:
 
     - name: Upload Unit Test Results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: Unit Test Results (Spark ${{ inputs.spark-version }}, Scala ${{ inputs.scala-version}}, Dgraph ${{ inputs.dgraph-version }}, Python ${{ inputs.python-version }})
         path: |

--- a/.github/actions/test-scala/action.yml
+++ b/.github/actions/test-scala/action.yml
@@ -32,19 +32,19 @@ runs:
       shell: bash
 
     - name: Fetch Binaries Artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: Binaries-${{ inputs.spark-compat-version }}-${{ inputs.scala-compat-version }}
         path: .
 
     - name: Fetch Dependencies Artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: Dependencies-${{ inputs.spark-compat-version }}-${{ inputs.scala-compat-version }}
         path: ~/.m2/repository
 
     - name: Setup JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
       with:
         java-version: ${{ inputs.java-version }}
         distribution: 'zulu'
@@ -78,7 +78,7 @@ runs:
 
     - name: Upload Unit Test Results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: Unit Test Results (Spark ${{ inputs.spark-version }}, Scala ${{ inputs.scala-version}}, Dgraph ${{ inputs.dgraph-version }})
         path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Build
         uses: ./.github/actions/build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: Event File
           path: ${{ github.event_path }}
@@ -25,18 +25,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-mvn-lint-${{ hashFiles('pom.xml') }}
 
       - name: Setup JDK ${{ inputs.java-compat-version }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:
           java-version: '11'
           distribution: 'zulu'
@@ -143,7 +143,7 @@ jobs:
     needs: [test-dgraph, test-spark, test-scala, test-python, test-integration]
     steps:
       - name: Delete Artifacts
-        uses: geekyeggo/delete-artifact@v5
+        uses: geekyeggo/delete-artifact@f275313e70c08f6120db482d7a6b98377786765b # v5.1.0
         with:
           name: |
             Binaries-*

--- a/.github/workflows/download-spark.yml
+++ b/.github/workflows/download-spark.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Cache Spark Binaries
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/spark
           key: ${{ runner.os }}-spark-binaries-${{ matrix.spark-version }}-${{ matrix.scala-compat-version }}
@@ -51,7 +51,7 @@ jobs:
         shell: bash
 
       - name: Upload Spark Binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: Spark-Binaries-${{ matrix.spark-version }}-${{ matrix.hadoop-version }}
           path: ~/spark

--- a/.github/workflows/test-dgraph.yml
+++ b/.github/workflows/test-dgraph.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Test
         uses: ./.github/actions/test-scala

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -106,7 +106,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Test
         uses: ./.github/actions/test-integrate

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Test
         uses: ./.github/actions/test-python

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Download and Extract Artifacts
-        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe
+        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
         with:
           run_id: ${{ github.event.workflow_run.id }}
           name: "Unit Test Results |Event File"
@@ -26,7 +26,7 @@ jobs:
           path: artifacts
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/Event File/event.json

--- a/.github/workflows/test-scala.yml
+++ b/.github/workflows/test-scala.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Test
         uses: ./.github/actions/test-scala

--- a/.github/workflows/test-spark.yml
+++ b/.github/workflows/test-spark.yml
@@ -146,7 +146,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Test
         uses: ./.github/actions/test-scala


### PR DESCRIPTION
## What

Pin all GitHub Actions references to full commit SHAs (with trailing `# <version>` comments), across the workflows and the four local composite actions under `.github/actions/`.

Ref: G-Research/gr-oss#1358

## Why

A mutable `@vN` ref can be silently rewritten upstream or by a compromised account and is picked up immediately by every workflow run. Pinning to an immutable commit SHA closes that supply-chain risk; the trailing `# <version>` comment keeps the pin human-readable.

## Notes

- Composite actions (`.github/actions/build`, `test-integrate`, `test-python`, `test-scala`) were pinned as well.
- `dawidd6/action-download-artifact` was already SHA-pinned but lacked a version comment; `# v3.1.4` was added.
- `actions/setup-java` appears at both v3 (workflow) and v4 (composites); each pinned to that major's current SHA.
- Local references (`./.github/actions/*`, `./.github/workflows/*`) are left as-is (not pinnable).
- Dependabot already scans the `github-actions` ecosystem here; no Dependabot change needed.