### PR TITLE
Upgrade dgraph4j, exclude shaded dependencies

### DIFF
--- a/.github/actions/test-integrate/action.yml
+++ b/.github/actions/test-integrate/action.yml
@@ -75,26 +75,6 @@ runs:
       run: |
         mvn --batch-mode -Dspotless.check.skip -DskipTests install
         (cd examples/scala && mvn --batch-mode -Dspotless.check.skip package)
-        # spark-submit is not capable of downloading these dependencies, fetching them through mvn
-        for dep in "org.slf4j#slf4j-api;2.0.16" \
-                   "com.google.protobuf#protobuf-java;4.29.1" \
-                   "io.netty#netty-all;4.1.110.Final" \
-                   "com.google.guava#guava;33.3.1-jre" \
-                   "com.google.guava#failureaccess;1.0.2" \
-                   "com.google.guava#listenablefuture;9999.0-empty-to-avoid-conflict-with-guava" \
-                   "org.checkerframework#checker-qual;3.43.0" \
-                   "com.google.j2objc#j2objc-annotations;3.0.0"; do
-          IFS="#;" read group artifact version <<< "$dep"
-          mvn --batch-mode -Dspotless.check.skip dependency:get -DgroupId="$group" -DartifactId="$artifact" -Dversion="$version"
-        done
-        if [[ "${{ inputs.spark-compat-version }}" == "3.0" ]]
-        then
-          # spark-submit 3.0 cannot resolve the dgraph4j dependency that has classifier "shaded"
-          # copying it into .ivy2 cache without classifier
-          mkdir -p ~/.ivy2/jars/
-          dgraph4j_version="$(grep -A3 -B2 "<artifactId>dgraph4j</artifactId>" pom.xml | grep "<version>" | sed -e "s/[^>]*>//" -e "s/<.*//")"
-          cp -v ~/.m2/repository/io/dgraph/dgraph4j/${dgraph4j_version}/dgraph4j-${dgraph4j_version}-shaded.jar ~/.ivy2/jars/io.dgraph_dgraph4j-${dgraph4j_version}.jar
-        fi
       shell: bash
 
     - name: Start Dgraph cluster (Small)

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,33 @@
       <artifactId>dgraph4j</artifactId>
       <version>24.1.1</version>
       <classifier>shaded</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-protobuf</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-netty</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-stub</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+        </exclusion>
+        <!-- runtime dependency -->
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <dependency>
       <groupId>io.dgraph</groupId>
       <artifactId>dgraph4j</artifactId>
-      <version>24.1.1</version>
+      <version>25.0.0</version>
       <classifier>shaded</classifier>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
## Checklist before submitting

- [X] Did you read the [contributing guide](https://github.com/G-Research/spark-dgraph-connector/blob/contributing-guidelines/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  

## Description

Upgrades dgraph4j dependency to 25.0.0. This also excludes all dependencies of the shaded dgraph4j jar. That should not have any dependencies in the first place, since it is shaded (it contains all dependencies), but given `shaded` is a classifier of the package, it cannot have its own pom, hence has the same dependencies as the main jar. The spark-dgraphconnector package now takes care of that.

## Review process for approval

1. All tests and other checks must succeed.
2. At least one core contributors must review and approve.
3. If a core contributor requests changes, they must be addressed.