### PR TITLE
[CI] Check shaded dgraph4j dependencies

### DIFF
--- a/.github/actions/test-integrate/action.yml
+++ b/.github/actions/test-integrate/action.yml
@@ -77,6 +77,11 @@ runs:
         (cd examples/scala && mvn --batch-mode -Dspotless.check.skip package)
       shell: bash
 
+    - name: Check shaded dgraph4j has no dependencies
+      run: |
+        ./examples/scala/check-dgraph4j-shading.sh
+      shell: bash
+
     - name: Start Dgraph cluster (Small)
       id: dgraph-small
       env:

--- a/.github/actions/test-integrate/action.yml
+++ b/.github/actions/test-integrate/action.yml
@@ -77,11 +77,6 @@ runs:
         (cd examples/scala && mvn --batch-mode -Dspotless.check.skip package)
       shell: bash
 
-    - name: Check shaded dgraph4j has no dependencies
-      run: |
-        ./examples/scala/check-dgraph4j-shading.sh
-      shell: bash
-
     - name: Start Dgraph cluster (Small)
       id: dgraph-small
       env:
@@ -154,6 +149,11 @@ runs:
         VERSION: ${{ steps.params.outputs.version }}
       run: |
         ${SPARK_HOME}/bin/spark-submit --packages uk.co.gresearch.spark:${ARTIFACT_ID}:${VERSION},org.scalactic:scalactic_2.12:3.2.15 --class uk.co.gresearch.spark.dgraph.connector.example.SparseApp examples/scala/target/spark-dgraph-connector-examples_*.jar
+      shell: bash
+
+    - name: Check shaded dgraph4j has no dependencies
+      run: |
+        ./examples/scala/check-dgraph4j-shading.sh
       shell: bash
 
 branding:

--- a/examples/scala/check-dgraph4j-shading.sh
+++ b/examples/scala/check-dgraph4j-shading.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+base="$(cd "$(dirname "$0")"; pwd)"
+
+# install spark-dgraph-connector
+(cd "$base/../.."; mvn --batch-mode -Dspotless.check.skip -DskipTests -Dmaven.test.skip=true install)
+
+# extract dependency tree
+(cd "$base"; mvn org.apache.maven.plugins:maven-dependency-plugin:3.7.0:tree -DoutputType=json -DoutputFile=dependency-tree.json)
+
+# extract children of dgraph4j dependency
+dependencies=$(jq '.children[] | select((.groupId == "uk.co.gresearch.spark") and (.artifactId | startswith("spark-dgraph-connector"))) | .children[] | select((.groupId == "io.dgraph") and (.artifactId == "dgraph4j")) | .children' < "$base/dependency-tree.json")
+
+# check there are no dependencies
+if [ "$dependencies" == "null" ]
+then
+  echo "Shaded dgraph4j dependency does not pull in any dependencies"
+else
+  echo "Shaded dgraph4j dependency has $(jq length <<< "$dependencies") dependencies"
+  exit 1
+fi


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributing guide](https://github.com/G-Research/spark-dgraph-connector/blob/contributing-guidelines/CONTRIBUTING.md)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?  

## Description

Looks like shaded dgraph4j dependency pulls all dependencies that is shades (includes in the jar). This is been dealt with in #289. Here, we make the CI check that no dependencies are pulled in. After merging #289, this test should go green.

## Review process for approval

1. All tests and other checks must succeed.
2. At least one core contributors must review and approve.
3. If a core contributor requests changes, they must be addressed.